### PR TITLE
Partially desimplify subproject CMakeLists.txt files

### DIFF
--- a/acquire-core-libs/CMakeLists.txt
+++ b/acquire-core-libs/CMakeLists.txt
@@ -2,5 +2,7 @@ project(acquire-core-libs)
 
 include(../cmake/msvc.cmake)
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 add_subdirectory(src)
 add_subdirectory(tests)

--- a/acquire-core-libs/CMakeLists.txt
+++ b/acquire-core-libs/CMakeLists.txt
@@ -1,4 +1,6 @@
 project(acquire-core-libs)
 
+include(../cmake/msvc.cmake)
+
 add_subdirectory(src)
 add_subdirectory(tests)

--- a/acquire-driver-common/CMakeLists.txt
+++ b/acquire-driver-common/CMakeLists.txt
@@ -3,5 +3,7 @@ project(acquire-driver-common)
 include(../cmake/msvc.cmake)
 include(../cmake/git-versioning.cmake)
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 add_subdirectory(src)
 add_subdirectory(tests)

--- a/acquire-driver-common/CMakeLists.txt
+++ b/acquire-driver-common/CMakeLists.txt
@@ -1,4 +1,7 @@
 project(acquire-driver-common)
 
+include(../cmake/msvc.cmake)
+include(../cmake/git-versioning.cmake)
+
 add_subdirectory(src)
 add_subdirectory(tests)

--- a/acquire-video-runtime/CMakeLists.txt
+++ b/acquire-video-runtime/CMakeLists.txt
@@ -1,4 +1,6 @@
 project(acquire-video-runtime)
 
+include(../cmake/msvc.cmake)
+
 add_subdirectory(src)
 add_subdirectory(tests)

--- a/acquire-video-runtime/CMakeLists.txt
+++ b/acquire-video-runtime/CMakeLists.txt
@@ -2,5 +2,7 @@ project(acquire-video-runtime)
 
 include(../cmake/msvc.cmake)
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 add_subdirectory(src)
 add_subdirectory(tests)


### PR DESCRIPTION
Needed to include subprojects individually in drivers (e.g., acquire-driver-zarr).