### PR TITLE
Acquisition dimension order in storage API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `reserve_image_shape` is now called in `acquire_configure` rather than `acquire_start`.
-- Users can now specify the names, ordering, and number of acquisition dimensions, as well as the append dimension.
+- Users can now specify the names, ordering, and number of acquisition dimensions.
 
 ## 0.2.0 - 2024-01-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `reserve_image_shape` is now called in `acquire_configure` rather than `acquire_start`.
-- Users can now specify chunk and shard dimensions in t, c, x, y, and x, as well as the append dimension.
+- Users can now specify chunk and shard acquisition_dimensions in t, c, x, y, and x, as well as the append dimension.
 
 ## 0.2.0 - 2024-01-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Users can now specify chunk and shard dimensions in t, c, x, y, and x, as well as the append dimension.
+
+## 0.2.0 - 2024-01-05
+
 ### Added
 
 - Additional validation in `test-change-external-metadata`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `reserve_image_shape` is now called in `acquire_configure` rather than `acquire_start`.
-- Users can now specify chunk and shard acquisition_dimensions in t, c, x, y, and x, as well as the append dimension.
+- Users can now specify the names, ordering, and number of acquisition dimensions, as well as the append dimension.
 
 ## 0.2.0 - 2024-01-05
 

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.c
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.c
@@ -165,18 +165,18 @@ Error:;
 }
 
 int
-storage_properties_dimensions_init(struct storage_properties_dimensions_s* self,
-                                   size_t size)
+storage_properties_dimensions_init(struct StorageProperties* self, size_t size)
 {
     CHECK(self);
     CHECK(size > 0);
-    CHECK(self->init);
-    CHECK(self->data == NULL);
+    CHECK(self->acquisition_dimensions.init);
+    CHECK(self->acquisition_dimensions.data == NULL);
 
-    (self->init)(&self->data, size);
-    CHECK(self->data);
+    (self->acquisition_dimensions.init)(&self->acquisition_dimensions.data,
+                                        size);
+    CHECK(self->acquisition_dimensions.data);
 
-    self->size = size;
+    self->acquisition_dimensions.size = size;
 
     return 1;
 Error:
@@ -184,16 +184,15 @@ Error:
 }
 
 int
-storage_properties_dimensions_destroy(
-  struct storage_properties_dimensions_s* self)
+storage_properties_dimensions_destroy(struct StorageProperties* self)
 {
     CHECK(self);
-    CHECK(self->destroy);
-    CHECK(self->data);
+    CHECK(self->acquisition_dimensions.destroy);
+    CHECK(self->acquisition_dimensions.data);
 
-    (self->destroy)(self->data);
-    self->data = NULL;
-    self->size = 0;
+    (self->acquisition_dimensions.destroy)(self->acquisition_dimensions.data);
+    self->acquisition_dimensions.data = NULL;
+    self->acquisition_dimensions.size = 0;
 
     return 1;
 Error:
@@ -273,7 +272,7 @@ storage_properties_destroy(struct StorageProperties* self)
         }
     }
 
-    storage_properties_dimensions_destroy(&self->acquisition_dimensions);
+    storage_properties_dimensions_destroy(self);
 }
 
 const char*
@@ -531,7 +530,7 @@ unit_test__storage_properties_dimensions_init()
     struct StorageProperties props = { 0 };
     props.acquisition_dimensions.init =
       storage_properties_dimensions__init_array;
-    CHECK(storage_properties_dimensions_init(&props.acquisition_dimensions, 5));
+    CHECK(storage_properties_dimensions_init(&props, 5));
 
     CHECK(props.acquisition_dimensions.size == 5);
     CHECK(props.acquisition_dimensions.data != NULL);
@@ -554,7 +553,7 @@ unit_test__storage_properties_dimensions_destroy()
       malloc(5 * sizeof(struct StorageDimension));
     props.acquisition_dimensions.size = 5;
 
-    CHECK(storage_properties_dimensions_destroy(&props.acquisition_dimensions));
+    CHECK(storage_properties_dimensions_destroy(&props));
     CHECK(props.acquisition_dimensions.size == 0);
     CHECK(props.acquisition_dimensions.data == NULL);
 

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.c
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.c
@@ -418,14 +418,14 @@ unit_test__storage_properties_set_chunking_props()
 
     const uint32_t x = 5, y = 4, z = 3, c = 2, t = 1;
     CHECK(storage_properties_set_chunking_props(
-      &props, x, y, z, c, t, AppendDimension_c));
+      &props, x, y, z, c, t, AppendDimension_C));
 
     CHECK(x == props.chunk_shape.x);
     CHECK(y == props.chunk_shape.y);
     CHECK(z == props.chunk_shape.z);
     CHECK(c == props.chunk_shape.c);
     CHECK(t == props.chunk_shape.t);
-    CHECK(props.append_dimension == AppendDimension_c);
+    CHECK(props.append_dimension == AppendDimension_C);
 
     storage_properties_destroy(&props);
 
@@ -438,7 +438,7 @@ int
 unit_test__storage_properties_default_append_dimension_is_t()
 {
     struct StorageProperties props = { 0 };
-    CHECK(props.append_dimension == AppendDimension_t);
+    CHECK(props.append_dimension == AppendDimension_T);
     return 1;
 Error:
     return 0;

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.c
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.c
@@ -224,7 +224,6 @@ storage_properties_set_append_dimension(struct StorageProperties* out,
                                         uint32_t index)
 {
     CHECK(out);
-    EXPECT(index > 1, "Invalid append dimension: %d.", index);
     EXPECT(index < countof(out->acquisition_dimensions),
            "Invalid dimension: %d.",
            index);
@@ -536,11 +535,7 @@ unit_test__storage_properties_set_append_dimension()
 {
     struct StorageProperties props = { 0 };
 
-    // x and y are forbidden
-    CHECK(!storage_properties_set_append_dimension(&props, 0));
-    CHECK(!storage_properties_set_append_dimension(&props, 1));
-
-    for (int i = 2; i < 8; ++i) {
+    for (int i = 0; i < 8; ++i) {
         CHECK(storage_properties_set_append_dimension(&props, i));
         CHECK(props.append_dimension == i);
     }

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.c
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.c
@@ -116,7 +116,7 @@ Error:
 }
 
 int
-storage_properties_insert_dimension(struct StorageProperties* out,
+storage_properties_dimension_insert(struct StorageProperties* out,
                                     uint32_t index,
                                     const char* name,
                                     size_t bytes_of_name,
@@ -155,7 +155,7 @@ Error:
 }
 
 int
-storage_properties_remove_dimension(struct StorageProperties* out,
+storage_properties_dimension_remove(struct StorageProperties* out,
                                     uint32_t index)
 {
     CHECK(out);
@@ -189,7 +189,7 @@ Error:
 }
 
 int
-storage_properties_get_dimension(
+storage_properties_dimension_get(
   const struct StorageProperties* out,
   uint32_t index,
   struct storage_properties_dimension_s* dimension)
@@ -562,19 +562,19 @@ unit_test__storage_properties_insert_dimension()
     CHECK(0 == storage_properties_dimension_count(&props));
 
     // can't skip an entry on insert
-    CHECK(!storage_properties_insert_dimension(
+    CHECK(!storage_properties_dimension_insert(
       &props, 1, "x", 2, DimensionType_Spatial, 1, 1, 1));
 
     // can't insert with a null char pointer
-    CHECK(!storage_properties_insert_dimension(
+    CHECK(!storage_properties_dimension_insert(
       &props, 0, NULL, 0, DimensionType_Spatial, 1, 1, 1));
 
     // can't insert with an empty name
-    CHECK(!storage_properties_insert_dimension(
+    CHECK(!storage_properties_dimension_insert(
       &props, 0, "", 0, DimensionType_Spatial, 1, 1, 1));
 
     // insert at 0
-    CHECK(storage_properties_insert_dimension(
+    CHECK(storage_properties_dimension_insert(
       &props, 0, "y", 2, DimensionType_Spatial, 1, 1, 1));
     CHECK(0 == strcmp(props.acquisition_dimensions[0].name.str, "y"));
     CHECK(props.acquisition_dimensions[0].kind == DimensionType_Spatial);
@@ -585,7 +585,7 @@ unit_test__storage_properties_insert_dimension()
     CHECK(1 == storage_properties_dimension_count(&props));
 
     // insert at 0 again
-    CHECK(storage_properties_insert_dimension(
+    CHECK(storage_properties_dimension_insert(
       &props, 0, "x", 2, DimensionType_Spatial, 2, 2, 2));
     CHECK(0 == strcmp(props.acquisition_dimensions[0].name.str, "x"));
     CHECK(props.acquisition_dimensions[0].kind == DimensionType_Spatial);
@@ -603,7 +603,7 @@ unit_test__storage_properties_insert_dimension()
     CHECK(2 == storage_properties_dimension_count(&props));
 
     // insert at 2
-    CHECK(storage_properties_insert_dimension(
+    CHECK(storage_properties_dimension_insert(
       &props, 2, "z", 2, DimensionType_Spatial, 3, 3, 3));
     CHECK(0 == strcmp(props.acquisition_dimensions[2].name.str, "z"));
     CHECK(props.acquisition_dimensions[2].kind == DimensionType_Spatial);
@@ -627,7 +627,7 @@ unit_test__storage_properties_insert_dimension()
     CHECK(3 == storage_properties_dimension_count(&props));
 
     // can't insert at 4 (would skip an entry)
-    CHECK(!storage_properties_insert_dimension(
+    CHECK(!storage_properties_dimension_insert(
       &props, 4, "t", 2, DimensionType_Time, 1, 1, 1));
 
     return 1;
@@ -642,10 +642,10 @@ unit_test__storage_properties_remove_dimension()
     CHECK(0 == storage_properties_dimension_count(&props));
 
     // can't remove at 0
-    CHECK(!storage_properties_remove_dimension(&props, 0));
+    CHECK(!storage_properties_dimension_remove(&props, 0));
 
     // insert at 0
-    CHECK(storage_properties_insert_dimension(
+    CHECK(storage_properties_dimension_insert(
       &props, 0, "x", 2, DimensionType_Spatial, 1, 1, 1));
     CHECK(0 == strcmp(props.acquisition_dimensions[0].name.str, "x"));
     CHECK(props.acquisition_dimensions[0].kind == DimensionType_Spatial);
@@ -656,11 +656,11 @@ unit_test__storage_properties_remove_dimension()
     CHECK(1 == storage_properties_dimension_count(&props));
 
     // insert at 1
-    CHECK(storage_properties_insert_dimension(
+    CHECK(storage_properties_dimension_insert(
       &props, 1, "y", 2, DimensionType_Spatial, 2, 2, 2));
 
     // remove at 0
-    CHECK(storage_properties_remove_dimension(&props, 0));
+    CHECK(storage_properties_dimension_remove(&props, 0));
 
     // dimension at 1 should have shifted down to 0
     CHECK(0 == strcmp(props.acquisition_dimensions[0].name.str, "y"));
@@ -682,7 +682,7 @@ unit_test__storage_properties_get_dimension()
 
     // trying to get an out of bounds dimension will fail
     struct storage_properties_dimension_s dim = { 0 };
-    CHECK(!storage_properties_get_dimension(&props, 0, &dim));
+    CHECK(!storage_properties_dimension_get(&props, 0, &dim));
 
     // check before we alter it
     CHECK(NULL == dim.name.str);
@@ -692,11 +692,11 @@ unit_test__storage_properties_get_dimension()
     CHECK(dim.shard_size_chunks == 0);
 
     // insert at 0
-    CHECK(storage_properties_insert_dimension(
+    CHECK(storage_properties_dimension_insert(
       &props, 0, "x", 2, DimensionType_Spatial, 1, 1, 1));
 
     // get at 0
-    CHECK(storage_properties_get_dimension(&props, 0, &dim));
+    CHECK(storage_properties_dimension_get(&props, 0, &dim));
     CHECK(0 == strcmp(dim.name.str, "x"));
     CHECK(dim.kind == DimensionType_Spatial);
     CHECK(dim.array_size_px == 1);
@@ -704,10 +704,10 @@ unit_test__storage_properties_get_dimension()
     CHECK(dim.shard_size_chunks == 1);
 
     // trying to get an oob dimension will still fail
-    CHECK(!storage_properties_get_dimension(&props, 1, &dim));
+    CHECK(!storage_properties_dimension_get(&props, 1, &dim));
 
     // should be unaltered
-    CHECK(storage_properties_get_dimension(&props, 0, &dim));
+    CHECK(storage_properties_dimension_get(&props, 0, &dim));
     CHECK(0 == strcmp(dim.name.str, "x"));
     CHECK(dim.kind == DimensionType_Spatial);
     CHECK(dim.array_size_px == 1);

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.c
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.c
@@ -59,6 +59,23 @@ Error:
     return 0;
 }
 
+static const char*
+dimension_type_as_string(enum DimensionType type)
+{
+    switch (type) {
+        case DimensionType_Space:
+            return "Spatial";
+        case DimensionType_Channel:
+            return "Channel";
+        case DimensionType_Time:
+            return "Time";
+        case DimensionType_Other:
+            return "Other";
+        default:
+            return "(unknown)";
+    }
+}
+
 static void
 storage_properties_dimensions__init_array(struct StorageDimension** data,
                                           size_t size)
@@ -273,23 +290,6 @@ storage_properties_destroy(struct StorageProperties* self)
     }
 
     storage_properties_dimensions_destroy(self);
-}
-
-const char*
-dimension_type_as_string(enum DimensionType type)
-{
-    switch (type) {
-        case DimensionType_Space:
-            return "Spatial";
-        case DimensionType_Channel:
-            return "Channel";
-        case DimensionType_Time:
-            return "Time";
-        case DimensionType_Other:
-            return "Other";
-        default:
-            return "(unknown)";
-    }
 }
 
 #ifndef NO_UNIT_TESTS

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.c
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.c
@@ -82,6 +82,23 @@ storage_properties_set_external_metadata(struct StorageProperties* out,
 }
 
 int
+storage_properties_set_array_extents(struct StorageProperties* out,
+                                     uint32_t x,
+                                     uint32_t y,
+                                     uint32_t z,
+                                     uint32_t c,
+                                     uint32_t t)
+{
+    CHECK(out);
+    out->array_extents = (struct storage_properties_array_extents_s){
+        x, y, z, c, t,
+    };
+    return 1;
+Error:
+    return 0;
+}
+
+int
 storage_properties_set_chunking_props(struct StorageProperties* out,
                                       uint32_t x,
                                       uint32_t y,
@@ -92,7 +109,7 @@ storage_properties_set_chunking_props(struct StorageProperties* out,
 {
     CHECK(out);
     CHECK(append_dimension < AppendDimensionCount);
-    out->chunk_size = (struct storage_properties_chunk_size_s){
+    out->chunk_shape = (struct storage_properties_chunk_shape_s){
         x, y, z, c, t,
     };
     out->append_dimension = append_dimension;
@@ -110,9 +127,8 @@ storage_properties_set_sharding_props(struct StorageProperties* out,
                                       uint32_t t)
 {
     CHECK(out);
-    out->shard_size_chunks = (struct storage_properties_shard_size_s){
-        x, y, z, c, t
-    };
+    out->shard_shape_chunks =
+      (struct storage_properties_shard_shape_s){ x, y, z, c, t };
     return 1;
 Error:
     return 0;
@@ -375,6 +391,27 @@ Error:
 }
 
 int
+unit_test__storage_properties_set_array_extents()
+{
+    struct StorageProperties props = { 0 };
+
+    const uint32_t x = 4, y = 3, z = 2, c = 1, t = 0;
+    CHECK(storage_properties_set_array_extents(&props, x, y, z, c, t));
+
+    CHECK(x == props.array_extents.x);
+    CHECK(y == props.array_extents.y);
+    CHECK(z == props.array_extents.z);
+    CHECK(c == props.array_extents.c);
+    CHECK(t == props.array_extents.t);
+
+    storage_properties_destroy(&props);
+
+    return 1;
+Error:
+    return 0;
+}
+
+int
 unit_test__storage_properties_set_chunking_props()
 {
     struct StorageProperties props = { 0 };
@@ -383,11 +420,11 @@ unit_test__storage_properties_set_chunking_props()
     CHECK(storage_properties_set_chunking_props(
       &props, x, y, z, c, t, AppendDimension_c));
 
-    CHECK(x == props.chunk_size.x);
-    CHECK(y == props.chunk_size.y);
-    CHECK(z == props.chunk_size.z);
-    CHECK(c == props.chunk_size.c);
-    CHECK(t == props.chunk_size.t);
+    CHECK(x == props.chunk_shape.x);
+    CHECK(y == props.chunk_shape.y);
+    CHECK(z == props.chunk_shape.z);
+    CHECK(c == props.chunk_shape.c);
+    CHECK(t == props.chunk_shape.t);
     CHECK(props.append_dimension == AppendDimension_c);
 
     storage_properties_destroy(&props);
@@ -415,11 +452,11 @@ unit_test__storage_properties_set_sharding_props()
     const uint32_t x = 5, y = 4, z = 3, c = 2, t = 1;
     CHECK(storage_properties_set_sharding_props(&props, x, y, z, c, t));
 
-    CHECK(x == props.shard_size_chunks.x);
-    CHECK(y == props.shard_size_chunks.y);
-    CHECK(z == props.shard_size_chunks.z);
-    CHECK(c == props.shard_size_chunks.c);
-    CHECK(t == props.shard_size_chunks.t);
+    CHECK(x == props.shard_shape_chunks.x);
+    CHECK(y == props.shard_shape_chunks.y);
+    CHECK(z == props.shard_shape_chunks.z);
+    CHECK(c == props.shard_shape_chunks.c);
+    CHECK(t == props.shard_shape_chunks.t);
 
     storage_properties_destroy(&props);
 

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.c
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.c
@@ -91,6 +91,7 @@ storage_properties_set_chunking_props(struct StorageProperties* out,
                                       enum AppendDimension append_dimension)
 {
     CHECK(out);
+    CHECK(append_dimension < AppendDimensionCount);
     out->chunk_size = (struct storage_properties_chunk_size_s){
         x, y, z, c, t,
     };
@@ -109,11 +110,9 @@ storage_properties_set_sharding_props(struct StorageProperties* out,
                                       uint32_t t)
 {
     CHECK(out);
-    out->shard_size_chunks.x = x;
-    out->shard_size_chunks.y = y;
-    out->shard_size_chunks.z = z;
-    out->shard_size_chunks.c = c;
-    out->shard_size_chunks.t = t;
+    out->shard_size_chunks = (struct storage_properties_shard_size_s){
+        x, y, z, c, t
+    };
     return 1;
 Error:
     return 0;

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
@@ -184,9 +184,6 @@ extern "C"
     /// @returns 1 on success, otherwise 0
     int storage_properties_dimensions_destroy(struct StorageProperties* self);
 
-    /// @brief Convert a DimensionType to a string.
-    const char* dimension_type_as_string(enum DimensionType type);
-
 #ifdef __cplusplus
 }
 #endif

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
@@ -71,20 +71,9 @@ extern "C"
 
     struct StoragePropertyMetadata
     {
-        struct storage_property_metadata_chunking_s
-        {
-            uint8_t is_supported;
-        } chunking;
-
-        struct storage_property_metadata_sharding_s
-        {
-            uint8_t is_supported;
-        } sharding;
-
-        struct storage_property_metadata_multiscale_s
-        {
-            uint8_t is_supported;
-        } multiscale;
+        uint8_t chunking_is_supported;
+        uint8_t sharding_is_supported;
+        uint8_t multiscale_is_supported;
     };
 
     /// Initializes StorageProperties, allocating string storage on the heap

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
@@ -58,6 +58,16 @@ extern "C"
 
     struct StoragePropertyMetadata
     {
+        struct storage_property_metadata_chunking_s
+        {
+            uint8_t is_supported;
+        } chunking;
+
+        struct storage_property_metadata_sharding_s
+        {
+            uint8_t is_supported;
+        } sharding;
+
         struct storage_property_metadata_multiscale_s
         {
             uint8_t is_supported;

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
@@ -117,6 +117,38 @@ extern "C"
                                                  const char* metadata,
                                                  size_t bytes_of_metadata);
 
+    /// @brief Initialize the dimension struct in `out`.
+    /// @param[out] out The dimension struct to initialize.
+    /// @param[in] name The name of the dimension.
+    /// @param[in] bytes_of_name The number of bytes in the name buffer.
+    ///                          Should include the terminating NULL.
+    /// @param[in] kind The type of dimension.
+    /// @param[in] array_size_px The size of the array along this dimension.
+    /// @param[in] chunk_size_px The size of a chunk along this dimension.
+    /// @param[in] shard_size_chunks The number of chunks in a shard along this
+    ///                              dimension.
+    /// @returns 1 on success, otherwise 0
+    int storage_properties_dimension_init(
+      struct storage_properties_dimension_s* out,
+      const char* name,
+      size_t bytes_of_name,
+      enum DimensionType kind,
+      uint32_t array_size_px,
+      uint32_t chunk_size_px,
+      uint32_t shard_size_chunks);
+
+    /// @brief Insert a dimension into `out` at `index`.
+    /// @param[out] out The storage properties containing the dimension array.
+    /// @param[in] index The index at which to insert the dimension.
+    /// @param[in] name The name of the dimension.
+    /// @param[in] bytes_of_name The number of bytes in the name buffer.
+    ///                          Should include the terminating NULL.
+    /// @param[in] kind The type of dimension.
+    /// @param[in] array_size_px The size of the array along this dimension.
+    /// @param[in] chunk_size_px The size of a chunk along this dimension.
+    /// @param[in] shard_size_chunks The number of chunks in a shard along this
+    ///                              dimension.
+    /// @returns 1 on success, otherwise 0
     int storage_properties_insert_dimension(struct StorageProperties* out,
                                             uint32_t index,
                                             const char* name,
@@ -126,19 +158,35 @@ extern "C"
                                             uint32_t chunk_size_px,
                                             uint32_t shard_size_chunks);
 
+    /// @brief Remove a dimension from `out` at `index`.
+    /// @param[out] out The storage properties containing the dimension array.
+    /// @param[in] index The index at which to remove the dimension.
+    /// @returns 1 on success, otherwise 0
     int storage_properties_remove_dimension(struct StorageProperties* out,
                                             uint32_t index);
 
+    /// @brief Get the number of dimensions in `out`.
+    /// @param[in] out The storage properties containing the dimension array.
+    /// @returns The number of dimensions in `out`.
     int storage_properties_dimension_count(const struct StorageProperties* out);
 
+    /// @brief Get the dimension at `index` in `out`.
+    /// @param[in] out The storage properties containing the dimension array.
+    /// @param[in] index The index at which to get the dimension.
+    /// @param[out] dimension The dimension at `index` in `out`.
     int storage_properties_get_dimension(
       const struct StorageProperties* out,
       uint32_t index,
       struct storage_properties_dimension_s* dimension);
 
+    /// @brief Destroy the dimension struct in `out`.
+    /// @param[out] out The dimension struct to destroy.
+    void storage_properties_dimension_destroy(
+      struct storage_properties_dimension_s* self);
+
     /// @brief Set the append dimension in `out`.
-    /// @note The first two dimensions are reserved for image dimensions and are
-    ///       not valid append dimensions.
+    /// @note The first two dimensions are reserved for image dimensions and
+    /// are not valid append dimensions.
     /// @returns 1 on success, otherwise 0
     int storage_properties_set_append_dimension(struct StorageProperties* out,
                                                 uint32_t index);

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
@@ -27,18 +27,25 @@ extern "C"
         uint32_t first_frame_id;
         struct PixelScale pixel_scale_um;
 
-        /// Dimensions of chunks, in pixels (x, y), stacks (z), channels (c),
-        /// and time (t).
-        struct storage_properties_chunk_size_s
+        /// Expected dimensions of the output array, in pixels (x, y), planes
+        /// (z), channels (c), and time (t).
+        struct storage_properties_array_extents_s
         {
             uint32_t x, y, z, c, t;
-        } chunk_size;
+        } array_extents;
+
+        /// Dimensions of chunks, in pixels (x, y), planes (z), channels (c),
+        /// and time (t).
+        struct storage_properties_chunk_shape_s
+        {
+            uint32_t x, y, z, c, t;
+        } chunk_shape;
 
         /// Dimensions of shards, in chunks.
-        struct storage_properties_shard_size_s
+        struct storage_properties_shard_shape_s
         {
             uint32_t x, y, z, c, t;
-        } shard_size_chunks;
+        } shard_shape_chunks;
 
         /// Which dimension to append frames along.
         enum AppendDimension append_dimension;
@@ -125,6 +132,28 @@ extern "C"
     int storage_properties_set_external_metadata(struct StorageProperties* out,
                                                  const char* metadata,
                                                  size_t bytes_of_metadata);
+
+    /// @brief Set the expected array dimensions for `out`.
+    /// Convenience function to set array extents in a single call.
+    /// @returns 1 on success, otherwise 0
+    /// @param[in, out] out The storage properties to change.
+    /// @param[in] x The width, in px, of the output array.
+    /// @param[in] y The height, in px, of the output array.
+    /// @param[in] z The expected number of planes per channel per time point in
+    /// the output array. If z is not the append dimension, 0 indicates that
+    /// this dimension should be skipped.
+    /// @param[in] c The expected number of channels in the output array. If c
+    /// is not the append dimension, 0 indicates that this dimension should be
+    /// skipped.
+    /// @param[in] t The expected number of time points in the output array. If
+    /// t is not the append dimension, 0 indicates that this dimension should be
+    /// skipped.
+    int storage_properties_set_array_extents(struct StorageProperties* out,
+                                             uint32_t x,
+                                             uint32_t y,
+                                             uint32_t z,
+                                             uint32_t c,
+                                             uint32_t t);
 
     /// @brief Set chunking properties for `out`.
     /// Convenience function to set chunking properties in a single call.

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
@@ -149,7 +149,7 @@ extern "C"
     /// @param[in] shard_size_chunks The number of chunks in a shard along this
     ///                              dimension.
     /// @returns 1 on success, otherwise 0
-    int storage_properties_insert_dimension(struct StorageProperties* out,
+    int storage_properties_dimension_insert(struct StorageProperties* out,
                                             uint32_t index,
                                             const char* name,
                                             size_t bytes_of_name,
@@ -162,7 +162,7 @@ extern "C"
     /// @param[out] out The storage properties containing the dimension array.
     /// @param[in] index The index at which to remove the dimension.
     /// @returns 1 on success, otherwise 0
-    int storage_properties_remove_dimension(struct StorageProperties* out,
+    int storage_properties_dimension_remove(struct StorageProperties* out,
                                             uint32_t index);
 
     /// @brief Get the number of dimensions in `out`.
@@ -174,7 +174,7 @@ extern "C"
     /// @param[in] out The storage properties containing the dimension array.
     /// @param[in] index The index at which to get the dimension.
     /// @param[out] dimension The dimension at `index` in `out`.
-    int storage_properties_get_dimension(
+    int storage_properties_dimension_get(
       const struct StorageProperties* out,
       uint32_t index,
       struct storage_properties_dimension_s* dimension);

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
@@ -70,6 +70,14 @@ extern "C"
 
     struct StoragePropertyMetadata
     {
+        /// Expected dimensions of the output array, in pixels (x, y), planes
+        /// (z), channels (c), and time (t).
+        struct storage_property_metadata_array_extents_s
+        {
+            uint8_t is_supported;
+            struct Property x, y, z, c, t;
+        } array_extents;
+
         /// Metadata for chunking.
         /// Indicates whether chunking is supported, and if so, bounds on what
         /// the dimensions of the chunks are.
@@ -77,7 +85,7 @@ extern "C"
         {
             uint8_t is_supported;
             struct Property x, y, z, c, t;
-        } chunk_size;
+        } chunk_shape;
 
         /// Metadata for sharding.
         /// Indicates whether sharding is supported, and if so, bounds on what
@@ -86,7 +94,7 @@ extern "C"
         {
             uint8_t is_supported;
             struct Property x, y, z, c, t;
-        } shard_size_chunks;
+        } shard_shape_chunks;
 
         struct storage_property_metadata_multiscale_s
         {

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
@@ -11,6 +11,14 @@ extern "C"
     struct DeviceManager;
     struct VideoFrame;
 
+    enum AppendDimension
+    {
+        AppendDimension_t = 0,
+        AppendDimension_c,
+        AppendDimension_z,
+        AppendDimensionCount
+    };
+
     /// Properties for a storage driver.
     struct StorageProperties
     {
@@ -19,17 +27,21 @@ extern "C"
         uint32_t first_frame_id;
         struct PixelScale pixel_scale_um;
 
-        /// Dimensions of chunks, in pixels.
-        struct storage_properties_chunking_s
+        /// Dimensions of chunks, in pixels (x, y), stacks (z), channels (c),
+        /// and time (t).
+        struct storage_properties_chunk_size_s
         {
-            uint32_t width, height, planes;
-        } chunk_dims_px;
+            uint32_t x, y, z, c, t;
+        } chunk_size;
 
         /// Dimensions of shards, in chunks.
-        struct storage_properties_sharding_s
+        struct storage_properties_shard_size_s
         {
-            uint32_t width, height, planes;
-        } shard_dims_chunks;
+            uint32_t x, y, z, c, t;
+        } shard_size_chunks;
+
+        /// Which dimension to append frames along.
+        enum AppendDimension append_dimension;
 
         /// Enable multiscale storage if true.
         uint8_t enable_multiscale;
@@ -39,12 +51,12 @@ extern "C"
     {
         /// Metadata for chunking.
         /// Indicates whether chunking is supported, and if so, bounds on what
-        /// the dimensions (in px) of the chunks are.
+        /// the dimensions of the chunks are.
         struct storage_property_metadata_chunking_s
         {
             uint8_t is_supported;
-            struct Property width, height, planes;
-        } chunk_dims_px;
+            struct Property x, y, z, c, t;
+        } chunk_size;
 
         /// Metadata for sharding.
         /// Indicates whether sharding is supported, and if so, bounds on what
@@ -52,8 +64,8 @@ extern "C"
         struct storage_property_metadata_sharding_s
         {
             uint8_t is_supported;
-            struct Property width, height, planes;
-        } shard_dims_chunks;
+            struct Property x, y, z, c, t;
+        } shard_size_chunks;
 
         struct storage_property_metadata_multiscale_s
         {
@@ -118,29 +130,37 @@ extern "C"
     /// Convenience function to set chunking properties in a single call.
     /// @returns 1 on success, otherwise 0
     /// @param[in, out] out The storage properties to change.
-    /// @param[in] chunk_width The width, in px, of a chunk.
-    /// @param[in] chunk_height The height, in px, of a chunk.
-    /// @param[in] chunk_planes The number of @p chunk_width x @p chunk_height
+    /// @param[in] x The width, in px, of a chunk.
+    /// @param[in] y The height, in px, of a chunk.
+    /// @param[in] z The number of @p chunk_width x @p chunk_height
     ///            planes in a single chunk.
-    int storage_properties_set_chunking_props(struct StorageProperties* out,
-                                              uint32_t chunk_width,
-                                              uint32_t chunk_height,
-                                              uint32_t chunk_planes);
+    /// @param[in] c The number of channels in a single chunk.
+    /// @param[in] t The number of time points in a single chunk.
+    /// @param[in] append_dimension The dimension to append frames along.
+    int storage_properties_set_chunking_props(
+      struct StorageProperties* out,
+      uint32_t x,
+      uint32_t y,
+      uint32_t z,
+      uint32_t c,
+      uint32_t t,
+      enum AppendDimension append_dimension);
 
     /// @brief Set sharding properties for `out`.
     /// Convenience function to set sharding properties in a single call.
     /// @returns 1 on success, otherwise 0
     /// @param[in, out] out The storage properties to change.
-    /// @param[in] shard_width The number of chunks in a shard along the x
-    ///            dimension.
-    /// @param[in] shard_height The number of chunks in a shard along the y
-    ///            dimension.
-    /// @param[in] shard_planes The number of chunks in a shard along the append
-    ///            dimension.
+    /// @param[in] x The number of chunks in a shard along the x dimension.
+    /// @param[in] y The number of chunks in a shard along the y dimension.
+    /// @param[in] z The number of chunks in a shard along the z dimension.
+    /// @param[in] c The number of chunks in a shard along the c dimension.
+    /// @param[in] t The number of chunks in a shard along the t dimension.
     int storage_properties_set_sharding_props(struct StorageProperties* out,
-                                              uint32_t shard_width,
-                                              uint32_t shard_height,
-                                              uint32_t shard_planes);
+                                              uint32_t x,
+                                              uint32_t y,
+                                              uint32_t z,
+                                              uint32_t c,
+                                              uint32_t t);
 
     /// @brief Set multiscale properties for `out`.
     /// Convenience function to enable multiscale.

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
@@ -133,7 +133,7 @@ extern "C"
     /// @param[in] x The width, in px, of a chunk.
     /// @param[in] y The height, in px, of a chunk.
     /// @param[in] z The number of @p chunk_width x @p chunk_height
-    ///            planes in a single chunk.
+    ///            planes per channel per time point in a single chunk.
     /// @param[in] c The number of channels in a single chunk.
     /// @param[in] t The number of time points in a single chunk.
     /// @param[in] append_dimension The dimension to append frames along.

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
@@ -13,10 +13,21 @@ extern "C"
 
     enum AppendDimension
     {
-        AppendDimension_t = 0,
-        AppendDimension_c,
-        AppendDimension_z,
+        AppendDimension_T = 0,
+        AppendDimension_C,
+        AppendDimension_Z,
         AppendDimensionCount
+    };
+
+    enum AppendOrder
+    {
+        AppendOrder_ZCT = 0,
+        AppendOrder_ZTC,
+        AppendOrder_CZT,
+        AppendOrder_CTZ,
+        AppendOrder_TZC,
+        AppendOrder_TCZ,
+        AppendOrderCount
     };
 
     /// Properties for a storage driver.
@@ -49,6 +60,9 @@ extern "C"
 
         /// Which dimension to append frames along.
         enum AppendDimension append_dimension;
+
+        /// Order of dimensions to append frames along.
+        enum AppendOrder append_order;
 
         /// Enable multiscale storage if true.
         uint8_t enable_multiscale;

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
@@ -181,13 +181,21 @@ extern "C"
     /// @param[out] self The Dimension struct to destroy.
     void storage_dimension_destroy(struct StorageDimension* self);
 
-    int storage_properties_dimensions_init(
-      struct storage_properties_dimensions_s* self,
-      size_t size);
+    /// @brief Initialize the acquisition_dimensions array in `self`.
+    /// @param[out] self The StorageProperties struct containing the array to
+    ///                  initialize.
+    /// @param[in] size The number of dimensions to allocate.
+    /// @returns 1 on success, otherwise 0
+    int storage_properties_dimensions_init(struct StorageProperties* self,
+                                           size_t size);
 
-    int storage_properties_dimensions_destroy(
-      struct storage_properties_dimensions_s* self);
+    /// @brief Free the acquisition_dimensions array in `self`.
+    /// @param[out] self The StorageProperties struct containing the array to
+    ///                  destroy.
+    /// @returns 1 on success, otherwise 0
+    int storage_properties_dimensions_destroy(struct StorageProperties* self);
 
+    /// @brief Convert a DimensionType to a string.
     const char* dimension_type_as_string(enum DimensionType type);
 
 #ifdef __cplusplus

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
@@ -11,7 +11,8 @@ extern "C"
     struct DeviceManager;
     struct VideoFrame;
 
-    enum DimensionType {
+    enum DimensionType
+    {
         DimensionType_None = 0,
         DimensionType_Spatial,
         DimensionType_Channel,
@@ -27,15 +28,27 @@ extern "C"
         uint32_t first_frame_id;
         struct PixelScale pixel_scale_um;
 
-        /// Dimensions of the output array, with array extents, chunk sizes, and shard sizes.
-        /// The first dimension is the fastest varying dimension. The last dimension is the append dimension.
-        struct Dimension {
-            struct String name;  // the name of the dimension as it appears in the metadata, e.g., "x", "y", "z", "c", "t"
-            enum DimensionType kind;  // the type of dimension, e.g., spatial, channel, time
-            uint32_t array_size_px;  // the expected size of the full output array along this dimension
-            uint32_t chunk_size_px;  // the size of a chunk along this dimension
-            uint32_t shard_size_chunks;  // the number of chunks in a shard along this dimension
-        } dimensions[8];
+        /// Dimensions of the output array, with array extents, chunk sizes, and
+        /// shard sizes. The first dimension is the fastest varying dimension.
+        /// The last dimension is the append dimension.
+        struct storage_properties_dimension_s
+        {
+            // the name of the dimension as it appears in the metadata, e.g.,
+            // "x", "y", "z", "c", "t"
+            struct String name;
+
+            // the type of dimension, e.g., spatial, channel, time
+            enum DimensionType kind;
+
+            // the expected size of the full output array along this dimension
+            uint32_t array_size_px;
+
+            // the size of a chunk along this dimension
+            uint32_t chunk_size_px;
+
+            // the number of chunks in a shard along this dimension
+            uint32_t shard_size_chunks;
+        } acquisition_dimensions[8];
 
         uint8_t append_dimension;
 
@@ -107,6 +120,7 @@ extern "C"
     int storage_properties_insert_dimension(struct StorageProperties* out,
                                             uint32_t index,
                                             const char* name,
+                                            size_t bytes_of_name,
                                             enum DimensionType kind,
                                             uint32_t array_size_px,
                                             uint32_t chunk_size_px,
@@ -117,63 +131,17 @@ extern "C"
 
     int storage_properties_dimension_count(const struct StorageProperties* out);
 
-    /// @brief Set the expected array dimensions for `out`.
-    /// Convenience function to set array extents in a single call.
-    /// @returns 1 on success, otherwise 0
-    /// @param[in, out] out The storage properties to change.
-    /// @param[in] x The width, in px, of the output array.
-    /// @param[in] y The height, in px, of the output array.
-    /// @param[in] z The expected number of planes per channel per time point in
-    /// the output array. If z is not the append dimension, 0 indicates that
-    /// this dimension should be skipped.
-    /// @param[in] c The expected number of channels in the output array. If c
-    /// is not the append dimension, 0 indicates that this dimension should be
-    /// skipped.
-    /// @param[in] t The expected number of time points in the output array. If
-    /// t is not the append dimension, 0 indicates that this dimension should be
-    /// skipped.
-    int storage_properties_set_array_extents(struct StorageProperties* out,
-                                             uint32_t x,
-                                             uint32_t y,
-                                             uint32_t z,
-                                             uint32_t c,
-                                             uint32_t t);
+    int storage_properties_get_dimension(
+      const struct StorageProperties* out,
+      uint32_t index,
+      struct storage_properties_dimension_s* dimension);
 
-    /// @brief Set chunking properties for `out`.
-    /// Convenience function to set chunking properties in a single call.
+    /// @brief Set the append dimension in `out`.
+    /// @note The first two dimensions are reserved for image dimensions and are
+    ///       not valid append dimensions.
     /// @returns 1 on success, otherwise 0
-    /// @param[in, out] out The storage properties to change.
-    /// @param[in] x The width, in px, of a chunk.
-    /// @param[in] y The height, in px, of a chunk.
-    /// @param[in] z The number of @p chunk_width x @p chunk_height
-    ///            planes per channel per time point in a single chunk.
-    /// @param[in] c The number of channels in a single chunk.
-    /// @param[in] t The number of time points in a single chunk.
-    /// @param[in] append_dimension The dimension to append frames along.
-    int storage_properties_set_chunking_props(
-      struct StorageProperties* out,
-      uint32_t x,
-      uint32_t y,
-      uint32_t z,
-      uint32_t c,
-      uint32_t t,
-      enum AppendDimension append_dimension);
-
-    /// @brief Set sharding properties for `out`.
-    /// Convenience function to set sharding properties in a single call.
-    /// @returns 1 on success, otherwise 0
-    /// @param[in, out] out The storage properties to change.
-    /// @param[in] x The number of chunks in a shard along the x dimension.
-    /// @param[in] y The number of chunks in a shard along the y dimension.
-    /// @param[in] z The number of chunks in a shard along the z dimension.
-    /// @param[in] c The number of chunks in a shard along the c dimension.
-    /// @param[in] t The number of chunks in a shard along the t dimension.
-    int storage_properties_set_sharding_props(struct StorageProperties* out,
-                                              uint32_t x,
-                                              uint32_t y,
-                                              uint32_t z,
-                                              uint32_t c,
-                                              uint32_t t);
+    int storage_properties_set_append_dimension(struct StorageProperties* out,
+                                                uint32_t index);
 
     /// @brief Set multiscale properties for `out`.
     /// Convenience function to enable multiscale.

--- a/acquire-core-libs/tests/unit-tests.cpp
+++ b/acquire-core-libs/tests/unit-tests.cpp
@@ -71,6 +71,7 @@ extern "C"
     int unit_test__storage__storage_property_string_check();
     int unit_test__storage__copy_string();
     int unit_test__storage_properties_set_chunking_props();
+    int unit_test__storage_properties_default_append_dimension_is_t();
     int unit_test__storage_properties_set_sharding_props();
     int unit_test__device_state_as_string__is_defined_for_all();
     int unit_test__device_kind_as_string__is_defined_for_all();
@@ -97,6 +98,7 @@ main()
         CASE(unit_test__storage__storage_property_string_check),
         CASE(unit_test__storage__copy_string),
         CASE(unit_test__storage_properties_set_chunking_props),
+        CASE(unit_test__storage_properties_default_append_dimension_is_t),
         CASE(unit_test__storage_properties_set_sharding_props),
         CASE(unit_test__device_state_as_string__is_defined_for_all),
         CASE(unit_test__device_kind_as_string__is_defined_for_all),

--- a/acquire-core-libs/tests/unit-tests.cpp
+++ b/acquire-core-libs/tests/unit-tests.cpp
@@ -70,10 +70,11 @@ extern "C"
     // device-properties
     int unit_test__storage__storage_property_string_check();
     int unit_test__storage__copy_string();
-    int unit_test__storage_properties_set_array_extents();
-    int unit_test__storage_properties_set_chunking_props();
-    int unit_test__storage_properties_default_append_dimension_is_t();
-    int unit_test__storage_properties_set_sharding_props();
+    int unit_test__storage_properties_dimension_count();
+    int unit_test__storage_properties_set_append_dimension();
+    int unit_test__storage_properties_insert_dimension();
+    int unit_test__storage_properties_remove_dimension();
+    int unit_test__storage_properties_get_dimension();
     int unit_test__device_state_as_string__is_defined_for_all();
     int unit_test__device_kind_as_string__is_defined_for_all();
     int unit_test__sample_type_as_string__is_defined_for_all();
@@ -98,10 +99,11 @@ main()
         CASE(unit_test__monotonic_clock_increases_monotonically),
         CASE(unit_test__storage__storage_property_string_check),
         CASE(unit_test__storage__copy_string),
-        CASE(unit_test__storage_properties_set_array_extents),
-        CASE(unit_test__storage_properties_set_chunking_props),
-        CASE(unit_test__storage_properties_default_append_dimension_is_t),
-        CASE(unit_test__storage_properties_set_sharding_props),
+        CASE(unit_test__storage_properties_dimension_count),
+        CASE(unit_test__storage_properties_set_append_dimension),
+        CASE(unit_test__storage_properties_insert_dimension),
+        CASE(unit_test__storage_properties_remove_dimension),
+        CASE(unit_test__storage_properties_get_dimension),
         CASE(unit_test__device_state_as_string__is_defined_for_all),
         CASE(unit_test__device_kind_as_string__is_defined_for_all),
         CASE(unit_test__sample_type_as_string__is_defined_for_all),

--- a/acquire-core-libs/tests/unit-tests.cpp
+++ b/acquire-core-libs/tests/unit-tests.cpp
@@ -70,14 +70,13 @@ extern "C"
     // device-properties
     int unit_test__storage__storage_property_string_check();
     int unit_test__storage__copy_string();
-    int unit_test__storage_properties_dimension_count();
-    int unit_test__storage_properties_set_append_dimension();
-    int unit_test__storage_properties_insert_dimension();
-    int unit_test__storage_properties_remove_dimension();
-    int unit_test__storage_properties_get_dimension();
+    int unit_test__dimension_init();
+    int unit_test__storage_properties_acquisition_dimensions_push_back();
+    int unit_test__storage_properties_acquisition_dimensions_remove();
     int unit_test__device_state_as_string__is_defined_for_all();
     int unit_test__device_kind_as_string__is_defined_for_all();
     int unit_test__sample_type_as_string__is_defined_for_all();
+    int unit_test__dimension_type_as_string__is_defined_for_all();
     int unit_test__bytes_of_type__is_defined_for_all();
 }
 
@@ -99,14 +98,13 @@ main()
         CASE(unit_test__monotonic_clock_increases_monotonically),
         CASE(unit_test__storage__storage_property_string_check),
         CASE(unit_test__storage__copy_string),
-        CASE(unit_test__storage_properties_dimension_count),
-        CASE(unit_test__storage_properties_set_append_dimension),
-        CASE(unit_test__storage_properties_insert_dimension),
-        CASE(unit_test__storage_properties_remove_dimension),
-        CASE(unit_test__storage_properties_get_dimension),
+        CASE(unit_test__dimension_init),
+        CASE(unit_test__storage_properties_acquisition_dimensions_push_back),
+        CASE(unit_test__storage_properties_acquisition_dimensions_remove),
         CASE(unit_test__device_state_as_string__is_defined_for_all),
         CASE(unit_test__device_kind_as_string__is_defined_for_all),
         CASE(unit_test__sample_type_as_string__is_defined_for_all),
+        CASE(unit_test__dimension_type_as_string__is_defined_for_all),
         CASE(unit_test__bytes_of_type__is_defined_for_all),
 #undef CASE
     };

--- a/acquire-core-libs/tests/unit-tests.cpp
+++ b/acquire-core-libs/tests/unit-tests.cpp
@@ -71,8 +71,8 @@ extern "C"
     int unit_test__storage__storage_property_string_check();
     int unit_test__storage__copy_string();
     int unit_test__dimension_init();
-    int unit_test__storage_properties_acquisition_dimensions_push_back();
-    int unit_test__storage_properties_acquisition_dimensions_remove();
+    int unit_test__storage_properties_dimensions_init();
+    int unit_test__storage_properties_dimensions_destroy();
     int unit_test__device_state_as_string__is_defined_for_all();
     int unit_test__device_kind_as_string__is_defined_for_all();
     int unit_test__sample_type_as_string__is_defined_for_all();
@@ -99,8 +99,8 @@ main()
         CASE(unit_test__storage__storage_property_string_check),
         CASE(unit_test__storage__copy_string),
         CASE(unit_test__dimension_init),
-        CASE(unit_test__storage_properties_acquisition_dimensions_push_back),
-        CASE(unit_test__storage_properties_acquisition_dimensions_remove),
+        CASE(unit_test__storage_properties_dimensions_init),
+        CASE(unit_test__storage_properties_dimensions_destroy),
         CASE(unit_test__device_state_as_string__is_defined_for_all),
         CASE(unit_test__device_kind_as_string__is_defined_for_all),
         CASE(unit_test__sample_type_as_string__is_defined_for_all),

--- a/acquire-core-libs/tests/unit-tests.cpp
+++ b/acquire-core-libs/tests/unit-tests.cpp
@@ -70,6 +70,7 @@ extern "C"
     // device-properties
     int unit_test__storage__storage_property_string_check();
     int unit_test__storage__copy_string();
+    int unit_test__storage_properties_set_array_extents();
     int unit_test__storage_properties_set_chunking_props();
     int unit_test__storage_properties_default_append_dimension_is_t();
     int unit_test__storage_properties_set_sharding_props();
@@ -97,6 +98,7 @@ main()
         CASE(unit_test__monotonic_clock_increases_monotonically),
         CASE(unit_test__storage__storage_property_string_check),
         CASE(unit_test__storage__copy_string),
+        CASE(unit_test__storage_properties_set_array_extents),
         CASE(unit_test__storage_properties_set_chunking_props),
         CASE(unit_test__storage_properties_default_append_dimension_is_t),
         CASE(unit_test__storage_properties_set_sharding_props),

--- a/acquire-driver-common/tests/devkit/storage-get-meta.cpp
+++ b/acquire-driver-common/tests/devkit/storage-get-meta.cpp
@@ -72,9 +72,6 @@ main()
                 storage = containerof(device, struct Storage, device);
 
                 CHECK(Device_Ok == storage_get_meta(storage, &metadata));
-                CHECK(0 == metadata.array_extents.is_supported);
-                CHECK(0 == metadata.chunk_shape.is_supported);
-                CHECK(0 == metadata.shard_shape_chunks.is_supported);
                 CHECK(0 == metadata.multiscale.is_supported);
 
                 CHECK(Device_Ok == driver_close_device(device));

--- a/acquire-driver-common/tests/devkit/storage-get-meta.cpp
+++ b/acquire-driver-common/tests/devkit/storage-get-meta.cpp
@@ -72,6 +72,8 @@ main()
                 storage = containerof(device, struct Storage, device);
 
                 CHECK(Device_Ok == storage_get_meta(storage, &metadata));
+                CHECK(0 == metadata.chunking.is_supported);
+                CHECK(0 == metadata.sharding.is_supported);
                 CHECK(0 == metadata.multiscale.is_supported);
 
                 CHECK(Device_Ok == driver_close_device(device));

--- a/acquire-driver-common/tests/devkit/storage-get-meta.cpp
+++ b/acquire-driver-common/tests/devkit/storage-get-meta.cpp
@@ -72,8 +72,9 @@ main()
                 storage = containerof(device, struct Storage, device);
 
                 CHECK(Device_Ok == storage_get_meta(storage, &metadata));
-                CHECK(0 == metadata.chunk_size.is_supported);
-                CHECK(0 == metadata.shard_size_chunks.is_supported);
+                CHECK(0 == metadata.array_extents.is_supported);
+                CHECK(0 == metadata.chunk_shape.is_supported);
+                CHECK(0 == metadata.shard_shape_chunks.is_supported);
                 CHECK(0 == metadata.multiscale.is_supported);
 
                 CHECK(Device_Ok == driver_close_device(device));

--- a/acquire-driver-common/tests/devkit/storage-get-meta.cpp
+++ b/acquire-driver-common/tests/devkit/storage-get-meta.cpp
@@ -72,8 +72,8 @@ main()
                 storage = containerof(device, struct Storage, device);
 
                 CHECK(Device_Ok == storage_get_meta(storage, &metadata));
-                CHECK(0 == metadata.chunk_dims_px.is_supported);
-                CHECK(0 == metadata.shard_dims_chunks.is_supported);
+                CHECK(0 == metadata.chunk_size.is_supported);
+                CHECK(0 == metadata.shard_size_chunks.is_supported);
                 CHECK(0 == metadata.multiscale.is_supported);
 
                 CHECK(Device_Ok == driver_close_device(device));

--- a/acquire-driver-common/tests/devkit/storage-get-meta.cpp
+++ b/acquire-driver-common/tests/devkit/storage-get-meta.cpp
@@ -72,9 +72,9 @@ main()
                 storage = containerof(device, struct Storage, device);
 
                 CHECK(Device_Ok == storage_get_meta(storage, &metadata));
-                CHECK(0 == metadata.chunking.is_supported);
-                CHECK(0 == metadata.sharding.is_supported);
-                CHECK(0 == metadata.multiscale.is_supported);
+                CHECK(0 == metadata.chunking_is_supported);
+                CHECK(0 == metadata.sharding_is_supported);
+                CHECK(0 == metadata.multiscale_is_supported);
 
                 CHECK(Device_Ok == driver_close_device(device));
             }

--- a/acquire-video-runtime/tests/CMakeLists.txt
+++ b/acquire-video-runtime/tests/CMakeLists.txt
@@ -4,7 +4,7 @@ else ()
     #
     # PARAMETERS
     #
-    set(project acquire-driver-runtime) # CMAKE_PROJECT_NAME gets overridden if this is a subtree of another project
+    set(project acquire-video-runtime) # CMAKE_PROJECT_NAME gets overridden if this is a subtree of another project
     set(driver acquire-driver-common)
 
     #


### PR DESCRIPTION
Allows users to specify the names, ordering, and number of acquisition dimensions.