### PR TITLE
Move `reserve_image_shape` from `acquire_start` to `acquire_configure`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- `reserve_image_shape` is now called in `acquire_configure` rather than `acquire_start`.
+
+## 0.2.0 - 2024-01-05
+
 ### Added
 
 - Additional validation in `test-change-external-metadata`.

--- a/acquire-video-runtime/src/acquire.c
+++ b/acquire-video-runtime/src/acquire.c
@@ -272,6 +272,7 @@ configure_video_stream(struct video_s* const video,
                             &pstorage->identifier,
                             &pstorage->settings,
                             pstorage->write_delay_ms) == Device_Ok);
+    is_ok &= reserve_image_shape(video);
 
     EXPECT(is_ok, "Failed to configure video stream.");
 
@@ -494,7 +495,6 @@ acquire_start(struct AcquireRuntime* self_)
         }
 
         CHECK(video_sink_start(&video->sink) == Device_Ok);
-        CHECK(reserve_image_shape(video));
         CHECK(video_filter_start(&video->filter) == Device_Ok);
         CHECK(video_source_start(&video->source) == Device_Ok);
 


### PR DESCRIPTION
Having `reserve_image_shape` in `acquire_start` was an annoying workaround from when the Storage object was created during start and destroyed on stop. But now that storage is created at the latest during configure, we can reserve image shape earlier in the process.