### PR TITLE
acquire_abort with no tears

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - A bug where changing device identifiers for the storage device was not being handled correctly.
+- A race condition where `camera_get_frame()` might be called after `camera_stop()` when aborting acquisition.
 
 ### Changed
 

--- a/acquire-core-libs/src/acquire-device-hal/device/hal/camera.c
+++ b/acquire-core-libs/src/acquire-device-hal/device/hal/camera.c
@@ -191,6 +191,7 @@ camera_get_frame(struct Camera* self,
                  struct ImageInfo* info)
 {
     CHECK(self);
+    CHECK(self->state == DeviceState_Running);
     enum DeviceStatusCode ecode = self->get_frame(self, im, nbytes, info);
     if (ecode != Device_Ok) {
         camera_stop(self);

--- a/acquire-core-libs/src/acquire-device-kit/device/kit/camera.h
+++ b/acquire-core-libs/src/acquire-device-kit/device/kit/camera.h
@@ -47,7 +47,7 @@ extern "C"
         ///          (i.e. one call of start after one call of stop should succeed).
         enum DeviceStatusCode (*stop)(struct Camera*);
 
-        /// @brief Execute the software trigger if it's enabled.
+        /// @brief Execute the software trigger.
         enum DeviceStatusCode (*execute_trigger)(struct Camera*);
 
         /// @brief Gets the next frame from the camera.

--- a/acquire-video-runtime/src/acquire.c
+++ b/acquire-video-runtime/src/acquire.c
@@ -575,7 +575,8 @@ acquire_abort(struct AcquireRuntime* self_)
 
         video->source.is_stopping = 1;
         channel_accept_writes(&video->sink.in, 0);
-        camera_stop(video->source.camera);
+        // if the camera is waiting on a trigger, this will unblock it.
+        camera_execute_trigger(video->source.camera);
     }
 
     return acquire_stop(self_);

--- a/acquire-video-runtime/src/acquire.c
+++ b/acquire-video-runtime/src/acquire.c
@@ -575,6 +575,7 @@ acquire_abort(struct AcquireRuntime* self_)
 
         video->source.is_stopping = 1;
         channel_accept_writes(&video->sink.in, 0);
+        camera_stop(video->source.camera);
     }
 
     return acquire_stop(self_);

--- a/acquire-video-runtime/src/acquire.c
+++ b/acquire-video-runtime/src/acquire.c
@@ -575,7 +575,6 @@ acquire_abort(struct AcquireRuntime* self_)
 
         video->source.is_stopping = 1;
         channel_accept_writes(&video->sink.in, 0);
-        camera_stop(video->source.camera);
     }
 
     return acquire_stop(self_);


### PR DESCRIPTION
- Checks that the camera is running when calling `camera_get_frame()`.
- Removes additional camera_stop in `acquire_abort()` (is already called at the end of `video_source_thread()``.
- Executes software trigger during abort, to prevent a deadlock in the case of the camera waiting on one while `acquire_abort()` is called.