### PR TITLE
fix acquire_configure

### DIFF
--- a/acquire-core-libs/src/acquire-device-hal/device/hal/device.manager.cpp
+++ b/acquire-core-libs/src/acquire-device-hal/device/hal/device.manager.cpp
@@ -402,3 +402,22 @@ device_manager_select(const struct DeviceManager* self,
     }
     return Device_Err;
 }
+
+enum DeviceStatusCode
+device_manager_select_default(const struct DeviceManager* self,
+                              enum DeviceKind kind,
+                              struct DeviceIdentifier* out)
+{
+    switch (kind) {
+        case DeviceKind_Camera:
+            return device_manager_select_inner_(
+              self, kind, ".*random.*", sizeof(".*random.*") - 1, out);
+        case DeviceKind_Storage:
+            return device_manager_select_inner_(
+              self, kind, "trash", sizeof("trash") - 1, out);
+        default:
+            LOGE("Invalid parameter `kind`. Got: %s",
+                 device_kind_as_string(kind));
+            return Device_Err;
+    }
+}

--- a/acquire-core-libs/src/acquire-device-hal/device/hal/device.manager.h
+++ b/acquire-core-libs/src/acquire-device-hal/device/hal/device.manager.h
@@ -63,6 +63,17 @@ extern "C"
       size_t bytes_of_name,
       struct DeviceIdentifier* out);
 
+    /// Query for the default device with a matching `kind`.
+    ///
+    /// @param self   The deviceManager context to query.
+    /// @param kind   The kind of device to select.
+    /// @param out    The id of the default device discovered that matches the
+    ///               `kind`.
+    enum DeviceStatusCode device_manager_select_default(
+      const struct DeviceManager* self,
+      enum DeviceKind kind,
+      struct DeviceIdentifier* out);
+
     struct Driver* device_manager_get_driver(
       const struct DeviceManager* self,
       const struct DeviceIdentifier* identifier);

--- a/acquire-core-libs/src/acquire-device-kit/device/kit/camera.h
+++ b/acquire-core-libs/src/acquire-device-kit/device/kit/camera.h
@@ -44,7 +44,8 @@ extern "C"
         /// @details This instructs the camera to stop and may block until it
         ///          actually has stopped acquiring frames.
         ///          The camera should also be restartable after calling this
-        ///          (i.e. one call of start after one call of stop should succeed).
+        ///          (i.e. one call of start after one call of stop should
+        ///          succeed).
         enum DeviceStatusCode (*stop)(struct Camera*);
 
         /// @brief Execute the software trigger.

--- a/acquire-core-libs/src/acquire-device-properties/device/props/camera.h
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/camera.h
@@ -13,12 +13,15 @@ extern "C"
 
     /// @brief Stores the properties of a camera.
     /// @details Can be populated with values from a camera or
-    ///          can be filled out to define new values that a camera should adopt.
+    ///          can be filled out to define new values that a camera should
+    ///          adopt.
     struct CameraProperties
     {
         /// @brief Exposure time of a frame in microseconds.
-        /// @details Acquire assumes that exposure is always manually specified by this period of time.
-        ///          It does not currently support auto-exposure or durations defined by trigger widths.
+        /// @details Acquire assumes that exposure is always manually specified
+        /// by this period of time.
+        ///          It does not currently support auto-exposure or durations
+        ///          defined by trigger widths.
         float exposure_time_us;
 
         float line_interval_us;
@@ -27,14 +30,15 @@ extern "C"
         /// @brief Binning or downsample factor.
         /// @details Determines how many pixels in each spatial dimension on the
         ///          sensor are aggregated to form pixels in an image.
-        ///          For example, if we have a sensor of size 1920x1200 and a binning
-        ///          factor of 2, one image should be 960x600.
+        ///          For example, if we have a sensor of size 1920x1200 and a
+        ///          binning factor of 2, one image should be 960x600.
         uint8_t binning;
 
         /// @brief Type of each image pixel or sample.
         enum SampleType pixel_type;
 
-        /// @brief Offset of the region of interest on the sensor from its top-left corner.
+        /// @brief Offset of the region of interest on the sensor from its
+        /// top-left corner.
         /// @details Each value represents a number of aggregated pixels in the
         ///          frame after binning has been applied.
         struct camera_properties_offset_s
@@ -87,11 +91,13 @@ extern "C"
 
         struct CameraPropertyMetadataDigitalLineMetadata
         {
-            /// @brief The number of supported digital IO lines. Must be less than 8.
+            /// @brief The number of supported digital IO lines. Must be less
+            /// than 8.
             uint8_t line_count;
 
             /// @brief Support describing up to 8 names for use with triggering.
-            /// @details name[i] is a short, null terminated string naming line i.
+            /// @details name[i] is a short, null terminated string naming line
+            /// i.
             char names[8][64];
         } digital_lines;
 
@@ -99,9 +105,11 @@ extern "C"
         {
             struct camera_properties_metadata_trigger_capabilities_s
             {
-                /// @brief Bit i is set if line i can be used as a trigger input.
+                /// @brief Bit i is set if line i can be used as a trigger
+                /// input.
                 uint8_t input;
-                /// @brief Bit i is set if line i can be used as a trigger output.
+                /// @brief Bit i is set if line i can be used as a trigger
+                /// output.
                 uint8_t output;
             } acquisition_start, exposure, frame_start;
         } triggers;

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.c
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.c
@@ -33,7 +33,7 @@ copy_string(struct String* dst, const struct String* src)
         // Allocate a new string on the heap.
         CHECK(dst->str = malloc(src->nbytes)); // NOLINT
         dst->nbytes = src->nbytes;
-        dst->is_ref = 0;                       // mark as owned
+        dst->is_ref = 0; // mark as owned
     }
 
     CHECK(dst->is_ref == 0);

--- a/acquire-video-runtime/src/acquire.c
+++ b/acquire-video-runtime/src/acquire.c
@@ -261,6 +261,11 @@ configure_video_stream(struct video_s* const video,
     struct aq_properties_storage_s* const pstorage = &pvideo->storage;
 
     int is_ok = 1;
+    if (pcamera->identifier.kind == DeviceKind_None) {
+        is_ok &= (Device_Ok == device_manager_select_default(
+                    device_manager, DeviceKind_Camera, &pcamera->identifier));
+    }
+
     is_ok &=
       (video_source_configure(&video->source,
                               device_manager,
@@ -270,6 +275,11 @@ configure_video_stream(struct video_s* const video,
                               pvideo->frame_average_count > 1) == Device_Ok);
     is_ok &= (video_filter_configure(&video->filter,
                                      pvideo->frame_average_count) == Device_Ok);
+
+    if (pstorage->identifier.kind == DeviceKind_None) {
+        is_ok &= (Device_Ok == device_manager_select_default(
+                                 device_manager, DeviceKind_Camera, &pstorage->identifier));
+    }
     is_ok &= (video_sink_configure(&video->sink,
                                    device_manager,
                                    &pstorage->identifier,
@@ -291,7 +301,7 @@ Error:
 static int
 video_stream_requirements_check(struct aq_properties_video_s* video_settings)
 {
-    if (video_settings->camera.identifier.kind == DeviceKind_None ||
+    if (video_settings->camera.identifier.kind == DeviceKind_None &&
         video_settings->storage.identifier.kind == DeviceKind_None) {
         return 0;
     }

--- a/acquire-video-runtime/src/acquire.c
+++ b/acquire-video-runtime/src/acquire.c
@@ -1,6 +1,7 @@
 #include "acquire.h"
 
 #include "device/hal/camera.h"
+#include "device/props/device.h"
 #include "logger.h"
 #include "platform.h"
 #include "runtime/channel.h"
@@ -10,6 +11,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+
+#define max(a, b) ((a) < (b) ? (b) : (a))
 
 #define containerof(ptr, T, V) ((T*)(((char*)(ptr)) - offsetof(T, V)))
 #define countof(e) (sizeof(e) / sizeof(*(e)))
@@ -258,20 +261,20 @@ configure_video_stream(struct video_s* const video,
     struct aq_properties_storage_s* const pstorage = &pvideo->storage;
 
     int is_ok = 1;
-    is_ok &= (video_source_configure(&video->source,
-                                     device_manager,
-                                     &pcamera->identifier,
-                                     &pcamera->settings,
-                                     pvideo->max_frame_count,
-                                     pvideo->frame_average_count > 1) == Device_Ok);
+    is_ok &=
+      (video_source_configure(&video->source,
+                              device_manager,
+                              &pcamera->identifier,
+                              &pcamera->settings,
+                              pvideo->max_frame_count,
+                              pvideo->frame_average_count > 1) == Device_Ok);
     is_ok &= (video_filter_configure(&video->filter,
                                      pvideo->frame_average_count) == Device_Ok);
-    is_ok &=
-      (video_sink_configure(&video->sink,
-                            device_manager,
-                            &pstorage->identifier,
-                            &pstorage->settings,
-                            pstorage->write_delay_ms) == Device_Ok);
+    is_ok &= (video_sink_configure(&video->sink,
+                                   device_manager,
+                                   &pstorage->identifier,
+                                   &pstorage->settings,
+                                   pstorage->write_delay_ms) == Device_Ok);
     is_ok &= reserve_image_shape(video);
 
     EXPECT(is_ok, "Failed to configure video stream.");
@@ -288,7 +291,7 @@ Error:
 static int
 video_stream_requirements_check(struct aq_properties_video_s* video_settings)
 {
-    if (video_settings->camera.identifier.kind == DeviceKind_None &&
+    if (video_settings->camera.identifier.kind == DeviceKind_None ||
         video_settings->storage.identifier.kind == DeviceKind_None) {
         return 0;
     }
@@ -322,9 +325,13 @@ acquire_configure(struct AcquireRuntime* self_,
         }
     }
     TRACE("Valid video streams: code %#04x", self->valid_video_streams);
-    self->state = self->valid_video_streams > 0
-                    ? DeviceState_Armed
-                    : DeviceState_AwaitingConfiguration;
+    if (self->valid_video_streams == 0) {
+        acquire_abort(self_); // aborts, moves to an Armed state
+        self->state = DeviceState_AwaitingConfiguration;
+    } else {
+        // success, moved to armed state or leave running
+        self->state = max(self->state, DeviceState_Armed);
+    }
     return AcquireStatus_Ok;
 Error:
     if (self_)

--- a/acquire-video-runtime/src/runtime/channel.h
+++ b/acquire-video-runtime/src/runtime/channel.h
@@ -27,13 +27,16 @@ extern "C"
         /// Position in the channel where the next write operation will occur.
         size_t head;
 
-        /// Highest position in the channel that has been written to in the current cycle.
+        /// Highest position in the channel that has been written to in the
+        /// current cycle.
         size_t high;
 
-        /// Number of times the buffer has been filled and wrapped around to the start.
+        /// Number of times the buffer has been filled and wrapped around to the
+        /// start.
         size_t cycle;
 
-        /// Pointer to the end position of the reserved region of a mapped write.
+        /// Pointer to the end position of the reserved region of a mapped
+        /// write.
         size_t mapped;
 
         /// Whether or not the channel is accepting writes.
@@ -44,7 +47,8 @@ extern "C"
         {
             size_t pos[8];
             size_t cycles[8];
-            unsigned n; /// Number of readers currently reading from the channel.
+            unsigned
+              n; /// Number of readers currently reading from the channel.
         } holds;
     };
 


### PR DESCRIPTION
see also: acquire-project/acquire-video-runtime#150

- updates how state changes are handled on success/failure
- the `video_stream_requirements_check` returns false if either the `camera` or `storage` device identifiers are `DeviceKind_None`. This means callers only need to set one to None to disable a video stream.
