### PR TITLE
Flesh out storage properties dimensions init and destroy

### DIFF
--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.c
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.c
@@ -200,20 +200,23 @@ Error:
     return 0;
 }
 
-int
+void
 storage_properties_dimensions_destroy(struct StorageProperties* self)
 {
     CHECK(self);
-    CHECK(self->acquisition_dimensions.destroy);
     CHECK(self->acquisition_dimensions.data);
+    CHECK(self->acquisition_dimensions.destroy);
 
+    // destroy each dimension
+    for (int i = 0; i < self->acquisition_dimensions.size; ++i) {
+        storage_dimension_destroy(&self->acquisition_dimensions.data[i]);
+    }
+
+    // destroy the array
     (self->acquisition_dimensions.destroy)(self->acquisition_dimensions.data);
-    self->acquisition_dimensions.data = NULL;
-    self->acquisition_dimensions.size = 0;
 
-    return 1;
-Error:
-    return 0;
+    memset(self, 0, sizeof(*self));
+Error:;
 }
 
 int
@@ -553,7 +556,7 @@ unit_test__storage_properties_dimensions_destroy()
       malloc(5 * sizeof(struct StorageDimension));
     props.acquisition_dimensions.size = 5;
 
-    CHECK(storage_properties_dimensions_destroy(&props));
+    storage_properties_dimensions_destroy(&props);
     CHECK(props.acquisition_dimensions.size == 0);
     CHECK(props.acquisition_dimensions.data == NULL);
 

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.c
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.c
@@ -275,6 +275,21 @@ storage_properties_copy(struct StorageProperties* dst,
     CHECK(
       copy_string(&dst->external_metadata_json, &src->external_metadata_json));
 
+    // 3. Copy the dimensions
+    if (src->acquisition_dimensions.data) {
+        dst->acquisition_dimensions.init = src->acquisition_dimensions.init;
+        dst->acquisition_dimensions.destroy =
+          src->acquisition_dimensions.destroy;
+
+        storage_properties_dimensions_destroy(dst);
+        CHECK(storage_properties_dimensions_init(
+          dst, src->acquisition_dimensions.size));
+        for (size_t i = 0; i < src->acquisition_dimensions.size; ++i) {
+            CHECK(storage_dimension_copy(&dst->acquisition_dimensions.data[i],
+                                         &src->acquisition_dimensions.data[i]));
+        }
+    }
+
     return 1;
 Error:
     return 0;

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.c
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.c
@@ -601,6 +601,9 @@ unit_test__storage_properties_dimensions_destroy()
     props.acquisition_dimensions.data =
       malloc(5 * sizeof(struct StorageDimension));
     props.acquisition_dimensions.size = 5;
+    memset(props.acquisition_dimensions.data,
+           0,
+           5 * sizeof(struct StorageDimension));
 
     storage_properties_dimensions_destroy(&props);
     CHECK(props.acquisition_dimensions.size == 0);

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.c
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.c
@@ -243,7 +243,7 @@ storage_properties_init(struct StorageProperties* out,
                         const char* metadata,
                         size_t bytes_of_metadata,
                         struct PixelScale pixel_scale_um,
-                        int dimension_count)
+                        uint8_t dimension_count)
 {
     // Allocate and copy filename
     memset(out, 0, sizeof(*out)); // NOLINT

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
@@ -181,8 +181,7 @@ extern "C"
     /// @brief Free the acquisition_dimensions array in `self`.
     /// @param[out] self The StorageProperties struct containing the array to
     ///                  destroy.
-    /// @returns 1 on success, otherwise 0
-    int storage_properties_dimensions_destroy(struct StorageProperties* self);
+    void storage_properties_dimensions_destroy(struct StorageProperties* self);
 
 #ifdef __cplusplus
 }

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
@@ -58,8 +58,33 @@ extern "C"
             // The number of dimensions in the output array.
             size_t size;
 
-            // Allocate storage for the dimensions.
-            void (*init)(struct StorageDimension**, size_t);
+            // Allocate storage for the dimensions. Implementations should
+            // initialize the `data` field to an array of `size` elements. The
+            // caller is responsible for freeing the storage when finished using
+            // the `destroy` function.
+            //
+            // If `size` is 0, the function should return 1 and set the `data`
+            // field to NULL. The caller is responsible for ensuring that this
+            // action does not leak memory.
+            //
+            // If `size` is non-zero and the `data` field is not NULL, the
+            // function will attempt to reallocate the `data` field to the new
+            // size. This may shrink the array if `size` is smaller than the
+            // current size, which may result in a memory leak, so the caller
+            // should ensure that those StorageDimension structs have been
+            // properly destroyed. If `data` is non-null but points to a block
+            // of memory that has been deallocated, the behavior is undefined,
+            // so the caller should ensure that the `data` field is NULL or has
+            // been properly initialized in advance.
+            //
+            // If allocation fails for any reason, the function should return 0
+            // and leave the `data` field unchanged. Otherwise, the function
+            // should return 1.
+            //
+            // @param[out] out The array of dimensions to initialize.
+            // @param[in] size The number of dimensions to allocate.
+            // @return 1 on success, otherwise 0.
+            int (*init)(struct StorageDimension**, size_t);
 
             // Free storage for the dimensions.
             void (*destroy)(struct StorageDimension*);

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
@@ -116,13 +116,16 @@ extern "C"
     /// @param[in] bytes_of_metadata Number of bytes in the `metadata` buffer
     ///                              including the terminating null.
     /// @param[in] pixel_scale_um The pixel scale or size in microns.
+    /// @param[in] dimension_count The number of dimensions in the storage
+    /// array.
     int storage_properties_init(struct StorageProperties* out,
                                 uint32_t first_frame_id,
                                 const char* filename,
                                 size_t bytes_of_filename,
                                 const char* metadata,
                                 size_t bytes_of_metadata,
-                                struct PixelScale pixel_scale_um);
+                                struct PixelScale pixel_scale_um,
+                                int dimension_count);
 
     /// Copies contents, reallocating string storage if necessary.
     /// @returns 1 on success, otherwise 0

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
@@ -57,37 +57,6 @@ extern "C"
 
             // The number of dimensions in the output array.
             size_t size;
-
-            // Allocate storage for the dimensions. Implementations should
-            // initialize the `data` field to an array of `size` elements. The
-            // caller is responsible for freeing the storage when finished using
-            // the `destroy` function.
-            //
-            // If `size` is 0, the function should return 1 and set the `data`
-            // field to NULL. The caller is responsible for ensuring that this
-            // action does not leak memory.
-            //
-            // If `size` is non-zero and the `data` field is not NULL, the
-            // function will attempt to reallocate the `data` field to the new
-            // size. This may shrink the array if `size` is smaller than the
-            // current size, which may result in a memory leak, so the caller
-            // should ensure that those StorageDimension structs have been
-            // properly destroyed. If `data` is non-null but points to a block
-            // of memory that has been deallocated, the behavior is undefined,
-            // so the caller should ensure that the `data` field is NULL or has
-            // been properly initialized in advance.
-            //
-            // If allocation fails for any reason, the function should return 0
-            // and leave the `data` field unchanged. Otherwise, the function
-            // should return 1.
-            //
-            // @param[out] out The array of dimensions to initialize.
-            // @param[in] size The number of dimensions to allocate.
-            // @return 1 on success, otherwise 0.
-            int (*init)(struct StorageDimension**, size_t);
-
-            // Free storage for the dimensions.
-            void (*destroy)(struct StorageDimension*);
         } acquisition_dimensions;
 
         /// Enable multiscale storage if true.
@@ -157,19 +126,11 @@ extern "C"
                                                  const char* metadata,
                                                  size_t bytes_of_metadata);
 
-    /// @brief Set multiscale properties for `out`.
-    /// Convenience function to enable multiscale.
-    /// @returns 1 on success, otherwise 0
-    /// @param[in, out] out The storage properties to change.
-    /// @param[in] enable A flag to enable or disable multiscale.
-    int storage_properties_set_enable_multiscale(struct StorageProperties* out,
-                                                 uint8_t enable);
-
-    /// Free's allocated string storage.
-    void storage_properties_destroy(struct StorageProperties* self);
-
-    /// @brief Initialize the Dimension struct in `out`.
-    /// @param[out] out The Dimension struct to initialize.
+    /// @brief Set the value of the StorageDimension struct at index `index` in
+    /// `out`.
+    /// @param[out] out The StorageProperties struct containing the
+    /// StorageDimension array.
+    /// @param[in] index The index of the dimension to set.
     /// @param[in] name The name of the dimension.
     /// @param[in] bytes_of_name The number of bytes in the name buffer.
     ///                          Should include the terminating NULL.
@@ -179,37 +140,25 @@ extern "C"
     /// @param[in] shard_size_chunks The number of chunks in a shard along this
     ///                              dimension.
     /// @returns 1 on success, otherwise 0
-    int storage_dimension_init(struct StorageDimension* out,
-                               const char* name,
-                               size_t bytes_of_name,
-                               enum DimensionType kind,
-                               uint32_t array_size_px,
-                               uint32_t chunk_size_px,
-                               uint32_t shard_size_chunks);
+    int storage_properties_set_dimension(struct StorageProperties* out,
+                                         int index,
+                                         const char* name,
+                                         size_t bytes_of_name,
+                                         enum DimensionType kind,
+                                         uint32_t array_size_px,
+                                         uint32_t chunk_size_px,
+                                         uint32_t shard_size_chunks);
 
-    /// @brief Copy the Dimension struct in `src` to `dst`.
-    /// @param[out] dst The Dimension struct to copy to.
-    /// @param[in] src The Dimension struct to copy from.
+    /// @brief Set multiscale properties for `out`.
+    /// Convenience function to enable multiscale.
     /// @returns 1 on success, otherwise 0
-    int storage_dimension_copy(struct StorageDimension* dst,
-                               const struct StorageDimension* src);
+    /// @param[in, out] out The storage properties to change.
+    /// @param[in] enable A flag to enable or disable multiscale.
+    int storage_properties_set_enable_multiscale(struct StorageProperties* out,
+                                                 uint8_t enable);
 
-    /// @brief Destroy the Dimension struct in `self`.
-    /// @param[out] self The Dimension struct to destroy.
-    void storage_dimension_destroy(struct StorageDimension* self);
-
-    /// @brief Initialize the acquisition_dimensions array in `self`.
-    /// @param[out] self The StorageProperties struct containing the array to
-    ///                  initialize.
-    /// @param[in] size The number of dimensions to allocate.
-    /// @returns 1 on success, otherwise 0
-    int storage_properties_dimensions_init(struct StorageProperties* self,
-                                           size_t size);
-
-    /// @brief Free the acquisition_dimensions array in `self`.
-    /// @param[out] self The StorageProperties struct containing the array to
-    ///                  destroy.
-    void storage_properties_dimensions_destroy(struct StorageProperties* self);
+    /// Free allocated string storage.
+    void storage_properties_destroy(struct StorageProperties* self);
 
 #ifdef __cplusplus
 }

--- a/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/storage.h
@@ -86,7 +86,8 @@ extern "C"
     ///                              including the terminating null.
     /// @param[in] pixel_scale_um The pixel scale or size in microns.
     /// @param[in] dimension_count The number of dimensions in the storage
-    /// array.
+    /// array. Each of the @p dimension_count dimensions will be initialized
+    /// to zero.
     int storage_properties_init(struct StorageProperties* out,
                                 uint32_t first_frame_id,
                                 const char* filename,
@@ -94,7 +95,7 @@ extern "C"
                                 const char* metadata,
                                 size_t bytes_of_metadata,
                                 struct PixelScale pixel_scale_um,
-                                int dimension_count);
+                                uint8_t dimension_count);
 
     /// Copies contents, reallocating string storage if necessary.
     /// @returns 1 on success, otherwise 0

--- a/acquire-driver-common/src/storage/raw.c
+++ b/acquire-driver-common/src/storage/raw.c
@@ -132,7 +132,8 @@ raw_init()
                                   sizeof("out.raw"),
                                   0,
                                   0,
-                                  pixel_scale_um));
+                                  pixel_scale_um,
+                                  0));
     self->writer =
       (struct Storage){ .state = DeviceState_AwaitingConfiguration,
                         .set = raw_set,

--- a/acquire-video-runtime/src/acquire.c
+++ b/acquire-video-runtime/src/acquire.c
@@ -12,7 +12,9 @@
 #include <stdio.h>
 #include <string.h>
 
+#ifndef max
 #define max(a, b) ((a) < (b) ? (b) : (a))
+#endif
 
 #define containerof(ptr, T, V) ((T*)(((char*)(ptr)) - offsetof(T, V)))
 #define countof(e) (sizeof(e) / sizeof(*(e)))
@@ -262,7 +264,8 @@ configure_video_stream(struct video_s* const video,
 
     int is_ok = 1;
     if (pcamera->identifier.kind == DeviceKind_None) {
-        is_ok &= (Device_Ok == device_manager_select_default(
+        is_ok &= (Device_Ok ==
+                  device_manager_select_default(
                     device_manager, DeviceKind_Camera, &pcamera->identifier));
     }
 
@@ -277,8 +280,9 @@ configure_video_stream(struct video_s* const video,
                                      pvideo->frame_average_count) == Device_Ok);
 
     if (pstorage->identifier.kind == DeviceKind_None) {
-        is_ok &= (Device_Ok == device_manager_select_default(
-                                 device_manager, DeviceKind_Storage, &pstorage->identifier));
+        is_ok &= (Device_Ok ==
+                  device_manager_select_default(
+                    device_manager, DeviceKind_Storage, &pstorage->identifier));
     }
     is_ok &= (video_sink_configure(&video->sink,
                                    device_manager,

--- a/acquire-video-runtime/src/acquire.c
+++ b/acquire-video-runtime/src/acquire.c
@@ -12,9 +12,8 @@
 #include <stdio.h>
 #include <string.h>
 
-#ifndef max
+#undef max
 #define max(a, b) ((a) < (b) ? (b) : (a))
-#endif
 
 #define containerof(ptr, T, V) ((T*)(((char*)(ptr)) - offsetof(T, V)))
 #define countof(e) (sizeof(e) / sizeof(*(e)))

--- a/acquire-video-runtime/tests/change-external-metadata.cpp
+++ b/acquire-video-runtime/tests/change-external-metadata.cpp
@@ -58,7 +58,8 @@ acquire(AcquireRuntime* runtime,
                             0,
                             external_metadata_json,
                             strlen(external_metadata_json) + 1,
-                            { 0, 0 });
+                            { 0, 0 },
+                            0);
 
     OK(acquire_configure(runtime, props));
     OK(acquire_start(runtime));
@@ -104,6 +105,8 @@ main()
     acquire(runtime, &props, R"({"foo": "bar"})");
     acquire(runtime, &props, R"({"hurley": "burley"})");
     acquire(runtime, &props, R"({})");
+
+    storage_properties_destroy(&props.video[0].storage.settings);
 
     LOG("DONE (OK)");
     acquire_shutdown(runtime);

--- a/acquire-video-runtime/tests/change-file-name.cpp
+++ b/acquire-video-runtime/tests/change-file-name.cpp
@@ -91,7 +91,7 @@ main()
 
     const char filename[] = "";
     storage_properties_init(
-      &props.video[0].storage.settings, 0, SIZED(filename), 0, 0, { 1, 1 });
+      &props.video[0].storage.settings, 0, SIZED(filename), 0, 0, { 1, 1 }, 0);
 
     acquire(runtime, &props, "out1.tif");
     acquire(runtime, &props, "quite a bit longer.tif");
@@ -99,6 +99,8 @@ main()
     acquire(runtime, &props, "quite a bit longer.tif"); // overwrite?
 
     LOG("DONE (OK)");
+    storage_properties_destroy(&props.video[0].storage.settings);
+
     acquire_shutdown(runtime);
     return 0;
 }

--- a/acquire-video-runtime/tests/one-video-stream.cpp
+++ b/acquire-video-runtime/tests/one-video-stream.cpp
@@ -68,7 +68,7 @@ main()
                                 &props.video[0].storage.identifier));
 
     storage_properties_init(
-      &props.video[0].storage.settings, 0, SIZED("out.tif"), 0, 0, { 0 });
+      &props.video[0].storage.settings, 0, SIZED("out.tif"), 0, 0, { 0 }, 0);
 
     OK(acquire_configure(runtime, &props));
 
@@ -137,6 +137,7 @@ main()
 
         CHECK(nframes == props.video[0].max_frame_count);
     }
+    storage_properties_destroy(&props.video[0].storage.settings);
 
     OK(acquire_stop(runtime));
     OK(acquire_shutdown(runtime));

--- a/acquire-video-runtime/tests/two-video-streams.cpp
+++ b/acquire-video-runtime/tests/two-video-streams.cpp
@@ -85,7 +85,8 @@ main()
                                   sizeof(filenames[0]),
                                   external_metadata,
                                   sizeof(external_metadata),
-                                  px_scale_um));
+                                  px_scale_um,
+                                  0));
 
     CHECK(storage_properties_init(&props.video[1].storage.settings,
                                   0,
@@ -93,7 +94,8 @@ main()
                                   sizeof(filenames[1]),
                                   external_metadata,
                                   sizeof(external_metadata),
-                                  { .x = 0, .y = 0 }));
+                                  { .x = 0, .y = 0 },
+                                  0));
 
     props.video[0].camera.settings.binning = 1;
     props.video[0].camera.settings.pixel_type = SampleType_u8;
@@ -167,6 +169,9 @@ main()
     }
 
     OK(acquire_stop(runtime));
+    storage_properties_destroy(&props.video[0].storage.settings);
+    storage_properties_destroy(&props.video[1].storage.settings);
+
     acquire_shutdown(runtime);
     return 0;
 }


### PR DESCRIPTION
- Document expected behavior for `storage_properties_dimensions_s::init`
- Change the return type of `storage_properties_dimensions_s::init` to int.
- Change the return type of `storage_properties_dimensions_destroy()` to void.
- Provide an official implementation for both init and destroy functions, set (and called) when calling `storage_properties_init()`.
- Add a parameter to `storage_properties_init()` specifying the number of acquisition dimensions.
- Put an `#ifndef` guard around the definition of `max` in acquire.c to suppress compiler warnings.
- Call `storage_properties_destroy()` for every `storage_properties_init()` in the tests.