### PR TITLE
Align `channel_write_map` requests to 8 bytes

### DIFF
--- a/acquire-core-libs/src/acquire-device-properties/device/props/components.c
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/components.c
@@ -52,6 +52,12 @@ bytes_of_type(enum SampleType type)
     return table[type];
 }
 
+size_t
+bytes_of_image(const struct ImageShape* const shape)
+{
+    return shape->strides.planes * bytes_of_type(shape->type);
+}
+
 //
 //  UNIT TESTS
 //

--- a/acquire-core-libs/src/acquire-device-properties/device/props/components.h
+++ b/acquire-core-libs/src/acquire-device-properties/device/props/components.h
@@ -143,6 +143,7 @@ extern "C"
 
     const char* sample_type_as_string(enum SampleType type);
     size_t bytes_of_type(enum SampleType type);
+    size_t bytes_of_image(const struct ImageShape* shape);
 
 #ifdef __cplusplus
 }

--- a/acquire-driver-common/src/simcams/simulated.camera.c
+++ b/acquire-driver-common/src/simcams/simulated.camera.c
@@ -86,12 +86,6 @@ struct SimulatedCamera
 };
 
 static size_t
-bytes_of_image(const struct ImageShape* const shape)
-{
-    return shape->strides.planes * bytes_of_type(shape->type);
-}
-
-static size_t
 aligned_bytes_of_image(const struct ImageShape* const shape)
 {
     const size_t n = bytes_of_image(shape);

--- a/acquire-video-runtime/src/runtime/filter.c
+++ b/acquire-video-runtime/src/runtime/filter.c
@@ -31,12 +31,6 @@ slice_size_bytes(const struct slice* slice)
     return (uint8_t*)slice->end - (uint8_t*)slice->beg;
 }
 
-static size_t
-bytes_of_image(const struct ImageShape* const shape)
-{
-    return shape->strides.planes * bytes_of_type(shape->type);
-}
-
 static int
 assert_consistent_shape(const struct VideoFrame* acc,
                         const struct VideoFrame* in)
@@ -113,8 +107,14 @@ process_data(struct video_filter_s* self,
             if (!*accumulator) {
                 struct ImageShape shape = in->shape;
                 shape.type = SampleType_f32;
-                size_t bytes_of_accumulator =
+
+                const size_t nbytes =
                   bytes_of_image(&shape) + sizeof(struct VideoFrame);
+                const size_t align = 8;
+                const size_t padding =
+                  (align - (nbytes & (align - 1))) & (align - 1);
+                const size_t bytes_of_accumulator = nbytes + padding;
+
                 *accumulator = (struct VideoFrame*)channel_write_map(
                   self->out, bytes_of_accumulator);
                 if (*accumulator) {

--- a/acquire-video-runtime/src/runtime/source.c
+++ b/acquire-video-runtime/src/runtime/source.c
@@ -60,9 +60,8 @@ video_source_thread(struct video_source_s* self)
 
         size_t sz = bytes_of_image(&info.shape);
         size_t nbytes = sizeof(struct VideoFrame) + sz;
-        const size_t align = 8;
-        const size_t padding = (align - (nbytes & (align - 1))) & (align - 1);
-        const size_t nbytes_aligned = nbytes + padding;
+        // padding to 8-byte aligned size
+        const size_t nbytes_aligned = 8*((nbytes+7)/8);
 
         struct channel* channel =
           (self->enable_filter) ? self->to_filter : self->to_sink;

--- a/acquire-video-runtime/src/runtime/source.c
+++ b/acquire-video-runtime/src/runtime/source.c
@@ -24,12 +24,6 @@
     } while (0)
 #define CHECK(e) EXPECT(e, "Expression evaluated as false:\n\t%s", #e)
 
-static size_t
-bytes_of_image(const struct ImageShape* const shape)
-{
-    return shape->strides.planes * bytes_of_type(shape->type);
-}
-
 static int
 check_frame_id(uint8_t stream_id,
                uint64_t iframe,
@@ -66,6 +60,9 @@ video_source_thread(struct video_source_s* self)
 
         size_t sz = bytes_of_image(&info.shape);
         size_t nbytes = sizeof(struct VideoFrame) + sz;
+        const size_t align = 8;
+        const size_t padding = (align - (nbytes & (align - 1))) & (align - 1);
+        const size_t nbytes_aligned = nbytes + padding;
 
         struct channel* channel =
           (self->enable_filter) ? self->to_filter : self->to_sink;
@@ -76,7 +73,7 @@ video_source_thread(struct video_source_s* self)
         last_stream = channel;
 
         struct VideoFrame* im =
-          (struct VideoFrame*)channel_write_map(channel, nbytes);
+          (struct VideoFrame*)channel_write_map(channel, nbytes_aligned);
         if (im) {
             CHECK(camera_get_frame(self->camera, im->data, &sz, &info) ==
                   Device_Ok);
@@ -88,7 +85,7 @@ video_source_thread(struct video_source_s* self)
                 last_hardware_frame_id = info.hardware_frame_id;
                 *im = (struct VideoFrame){
                     .shape = info.shape,
-                    .bytes_of_frame = nbytes,
+                    .bytes_of_frame = nbytes_aligned,
                     .frame_id = iframe,
                     .hardware_frame_id = info.hardware_frame_id,
                     .timestamps.hardware = info.hardware_timestamp,

--- a/acquire-video-runtime/tests/CMakeLists.txt
+++ b/acquire-video-runtime/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ else ()
             zero-config-start
             filter-video-average
             repeat-start-no-monitor
+            aligned-videoframe-pointers
     )
 
     foreach (name ${tests})

--- a/acquire-video-runtime/tests/aligned-videoframe-pointers.cpp
+++ b/acquire-video-runtime/tests/aligned-videoframe-pointers.cpp
@@ -62,6 +62,7 @@ configure(AcquireRuntime* runtime)
                                 SIZED("simulated.*empty.*") - 1,
                                 &props.video[0].camera.identifier));
 
+    // These settings are chosen to exercise the 8-byte alignment constraint.
     props.video[0].camera.settings.binning = 1;
     props.video[0].camera.settings.pixel_type = SampleType_u8;
     props.video[0].camera.settings.shape = {

--- a/acquire-video-runtime/tests/aligned-videoframe-pointers.cpp
+++ b/acquire-video-runtime/tests/aligned-videoframe-pointers.cpp
@@ -1,9 +1,8 @@
-/// @file one-video-stream.cpp
-/// Test that we can consistently acquire frames from a single video stream.
+/// @file aligned-videoframe-pointers.cpp
+/// Test that VideoFrame pointers are aligned at 8 bytes.
 
 #include "acquire.h"
 #include "device/hal/device.manager.h"
-#include "device/props/components.h"
 #include "platform.h"
 #include "logger.h"
 
@@ -24,12 +23,6 @@ reporter(int is_error,
             line,
             function,
             msg);
-}
-
-static size_t
-bytes_of_frame(const VideoFrame* frame)
-{
-    return sizeof(*frame) + bytes_of_image(&frame->shape);
 }
 
 /// Helper for passing size static strings as function args.
@@ -57,40 +50,44 @@ void
 configure(AcquireRuntime* runtime)
 {
     CHECK(runtime);
-
     const DeviceManager* dm = acquire_device_manager(runtime);
     CHECK(dm);
 
     AcquireProperties props = {};
     OK(acquire_get_configuration(runtime, &props));
 
+    // configure camera
     DEVOK(device_manager_select(dm,
                                 DeviceKind_Camera,
                                 SIZED("simulated.*empty.*") - 1,
                                 &props.video[0].camera.identifier));
-    DEVOK(device_manager_select(dm,
-                                DeviceKind_Storage,
-                                SIZED("tiff") - 1,
-                                &props.video[0].storage.identifier));
-
-    storage_properties_init(
-      &props.video[0].storage.settings, 0, SIZED("out.tif"), 0, 0, { 0 }, 0);
-
-    OK(acquire_configure(runtime, &props));
-
-    AcquirePropertyMetadata metadata = { 0 };
-    OK(acquire_get_configuration_metadata(runtime, &metadata));
 
     props.video[0].camera.settings.binning = 1;
-    props.video[0].camera.settings.pixel_type = SampleType_u12;
+    props.video[0].camera.settings.pixel_type = SampleType_u8;
     props.video[0].camera.settings.shape = {
-        .x = 1920,
-        .y = 1080,
+        .x = 33,
+        .y = 47,
     };
+
+    // configure acquisition
     props.video[0].max_frame_count = 10;
+
+    // configure storage
+    DEVOK(device_manager_select(dm,
+                                DeviceKind_Storage,
+                                SIZED("trash") - 1,
+                                &props.video[0].storage.identifier));
+    storage_properties_init(
+      &props.video[0].storage.settings, 0, nullptr, 0, nullptr, 0, { 0 }, 0);
 
     OK(acquire_configure(runtime, &props));
     storage_properties_destroy(&props.video[0].storage.settings);
+}
+
+static size_t
+align_up(size_t n, size_t align)
+{
+    return (n + align - 1) & ~(align - 1);
 }
 
 void
@@ -102,7 +99,8 @@ acquire(AcquireRuntime* runtime)
     OK(acquire_get_configuration(runtime, &props));
 
     const auto next = [](VideoFrame* cur) -> VideoFrame* {
-        return (VideoFrame*)(((uint8_t*)cur) + bytes_of_frame(cur));
+        return (VideoFrame*)(((uint8_t*)cur) +
+                             align_up(cur->bytes_of_frame, 8));
     };
 
     const auto consumed_bytes = [](const VideoFrame* const cur,
@@ -110,10 +108,10 @@ acquire(AcquireRuntime* runtime)
         return (uint8_t*)end - (uint8_t*)cur;
     };
 
-    struct clock clock = {};
+    struct clock clock
+    {};
     // expected time to acquire frames + 100%
-    static double time_limit_ms =
-      (props.video[0].max_frame_count / 6.0) * 1000.0 * 2.0;
+    static double time_limit_ms = props.video[0].max_frame_count * 1000.0 * 3.0;
     clock_init(&clock);
     clock_shift_ms(&clock, time_limit_ms);
     OK(acquire_start(runtime));
@@ -126,18 +124,38 @@ acquire(AcquireRuntime* runtime)
             EXPECT(clock_cmp_now(&clock) < 0,
                    "Timeout at %f ms",
                    clock_toc_ms(&clock) + time_limit_ms);
+
             VideoFrame *beg, *end, *cur;
             OK(acquire_map_read(runtime, 0, &beg, &end));
+
             for (cur = beg; cur < end; cur = next(cur)) {
                 LOG("stream %d counting frame w id %d", 0, cur->frame_id);
+
+                const size_t unpadded_bytes =
+                  bytes_of_image(&cur->shape) + sizeof(*cur);
+                const size_t alignment = 8;
+                const size_t padding =
+                  (alignment - (unpadded_bytes & (alignment - 1))) &
+                  (alignment - 1);
+                const size_t nbytes_aligned = unpadded_bytes + padding;
+
+                // check data is correct
+                CHECK(bytes_of_image(&cur->shape) == 33 * 47);
+                CHECK(cur->bytes_of_frame == nbytes_aligned);
+                CHECK(cur->frame_id == nframes);
                 CHECK(cur->shape.dims.width ==
                       props.video[0].camera.settings.shape.x);
                 CHECK(cur->shape.dims.height ==
                       props.video[0].camera.settings.shape.y);
+
+                // check pointer is aligned
+                CHECK((size_t)cur % 8 == 0);
                 ++nframes;
             }
+
             {
-                uint32_t n = (uint32_t)consumed_bytes(beg, end);
+                const auto n = (uint32_t)consumed_bytes(beg, end);
+                CHECK(n % 8 == 0);
                 OK(acquire_unmap_read(runtime, 0, n));
                 if (n)
                     LOG("stream %d consumed bytes %d", 0, n);
@@ -167,9 +185,7 @@ main()
         acquire(runtime);
         retval = 0;
     } catch (const std::exception& e) {
-        ERR("Failed to configure runtime: %s", e.what());
-    } catch (...) {
-        ERR("Failed to configure runtime: unknown error");
+        ERR("Exception: %s", e.what());
     }
 
     acquire_shutdown(runtime);


### PR DESCRIPTION
- Adds `bytes_of_image` to public API (components.h) and removes duplicate implementations in various .c files.
- Aligns all requests to `channel_write_map` to 8 bytes.
- Catch exceptions in `one-video-stream` test. 

Note: this PR is against the branch used (temporarily) by acquire-python. The same PR against main is [here](https://github.com/acquire-project/acquire-common/pull/45).