### PR TITLE
Fix warnings

### DIFF
--- a/acquire-driver-common/tests/integration/CMakeLists.txt
+++ b/acquire-driver-common/tests/integration/CMakeLists.txt
@@ -13,6 +13,7 @@ else ()
             abort-while-waiting-for-trigger
             configure-triggering
             list-digital-lines
+            simcam-will-not-stall
             software-trigger-acquires-single-frames
             switch-storage-identifier
             write-side-by-side-tiff

--- a/acquire-driver-common/tests/integration/simcam-will-not-stall.cpp
+++ b/acquire-driver-common/tests/integration/simcam-will-not-stall.cpp
@@ -1,0 +1,141 @@
+/// @file simcam-will-not-stall.cpp
+/// Test that we can acquire frames from a slow-moving camera without hanging.
+
+#include "acquire.h"
+#include "device/hal/device.manager.h"
+#include "platform.h"
+#include "logger.h"
+
+#include <cstdio>
+#include <stdexcept>
+
+void
+reporter(int is_error,
+         const char* file,
+         int line,
+         const char* function,
+         const char* msg)
+{
+    fprintf(is_error ? stderr : stdout,
+            "%s%s(%d) - %s: %s\n",
+            is_error ? "ERROR " : "",
+            file,
+            line,
+            function,
+            msg);
+}
+
+/// Helper for passing size static strings as function args.
+/// For a function: `f(char*,size_t)` use `f(SIZED("hello"))`.
+/// Expands to `f("hello",5)`.
+#define SIZED(str) str, sizeof(str)
+
+#define L (aq_logger)
+#define LOG(...) L(0, __FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+#define ERR(...) L(1, __FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+#define EXPECT(e, ...)                                                         \
+    do {                                                                       \
+        if (!(e)) {                                                            \
+            char buf[1 << 8] = { 0 };                                          \
+            ERR(__VA_ARGS__);                                                  \
+            snprintf(buf, sizeof(buf) - 1, __VA_ARGS__);                       \
+            throw std::runtime_error(buf);                                     \
+        }                                                                      \
+    } while (0)
+#define CHECK(e) EXPECT(e, "Expression evaluated as false: %s", #e)
+#define DEVOK(e) CHECK(Device_Ok == (e))
+#define OK(e) CHECK(AcquireStatus_Ok == (e))
+
+int
+main()
+{
+
+    auto runtime = acquire_init(reporter);
+    auto dm = acquire_device_manager(runtime);
+    CHECK(runtime);
+    CHECK(dm);
+
+    AcquireProperties props = {};
+    OK(acquire_get_configuration(runtime, &props));
+
+    DEVOK(device_manager_select(dm,
+                                DeviceKind_Camera,
+                                SIZED("simulated.*radial.*") - 1,
+                                &props.video[0].camera.identifier));
+    DEVOK(device_manager_select(dm,
+                                DeviceKind_Storage,
+                                SIZED("trash") - 1,
+                                &props.video[0].storage.identifier));
+
+    OK(acquire_configure(runtime, &props));
+
+    AcquirePropertyMetadata metadata = { 0 };
+    OK(acquire_get_configuration_metadata(runtime, &metadata));
+
+    props.video[0].camera.settings.binning = 1;
+    props.video[0].camera.settings.pixel_type = SampleType_u16;
+    props.video[0].camera.settings.shape = {
+        .x = 1920,
+        .y = 1080,
+    };
+    props.video[0].max_frame_count = 100;
+
+    OK(acquire_configure(runtime, &props));
+
+    const auto next = [](VideoFrame* cur) -> VideoFrame* {
+        return (VideoFrame*)(((uint8_t*)cur) + cur->bytes_of_frame);
+    };
+
+    const auto consumed_bytes = [](const VideoFrame* const cur,
+                                   const VideoFrame* const end) -> size_t {
+        return (uint8_t*)end - (uint8_t*)cur;
+    };
+
+    struct clock clock
+    {};
+    // expected time to acquire frames + 100%
+    static double time_limit_ms =
+      (props.video[0].max_frame_count / 6.0) * 1000.0 * 2.0;
+    clock_init(&clock);
+    clock_shift_ms(&clock, time_limit_ms);
+    OK(acquire_start(runtime));
+    {
+        uint64_t nframes = 0;
+        while (nframes < props.video[0].max_frame_count) {
+            struct clock throttle
+            {};
+            clock_init(&throttle);
+            EXPECT(clock_cmp_now(&clock) < 0,
+                   "Timeout at %f ms",
+                   clock_toc_ms(&clock) + time_limit_ms);
+            VideoFrame *beg, *end, *cur;
+            OK(acquire_map_read(runtime, 0, &beg, &end));
+            for (cur = beg; cur < end; cur = next(cur)) {
+                LOG("stream %d counting frame w id %d", 0, cur->frame_id);
+                CHECK(cur->shape.dims.width ==
+                      props.video[0].camera.settings.shape.x);
+                CHECK(cur->shape.dims.height ==
+                      props.video[0].camera.settings.shape.y);
+                ++nframes;
+            }
+            {
+                uint32_t n = (uint32_t)consumed_bytes(beg, end);
+                OK(acquire_unmap_read(runtime, 0, n));
+                if (n)
+                    LOG("stream %d consumed bytes %d", 0, n);
+            }
+            clock_sleep_ms(&throttle, 100.0f);
+
+            LOG("stream %d nframes %d. remaining time %f s",
+                0,
+                nframes,
+                -1e-3 * clock_toc_ms(&clock));
+        }
+
+        CHECK(nframes == props.video[0].max_frame_count);
+    }
+
+    OK(acquire_stop(runtime));
+    OK(acquire_shutdown(runtime));
+    return 0;
+}

--- a/acquire-driver-common/tests/integration/simcam-will-not-stall.cpp
+++ b/acquire-driver-common/tests/integration/simcam-will-not-stall.cpp
@@ -8,21 +8,49 @@
 
 #include <cstdio>
 #include <stdexcept>
+#include <string>
 
-void
+static class IntrospectiveLogger
+{
+  public:
+    IntrospectiveLogger()
+      : dropped_logs(0){};
+
+    // inspect for "[stream 0] Dropped", otherwise pass the mesage through
+    void report_and_inspect(int is_error,
+                            const char* file,
+                            int line,
+                            const char* function,
+                            const char* msg)
+    {
+        std::string m(msg);
+        if (m.length() >= 18 && m.substr(0, 18) == "[stream 0] Dropped")
+            ++dropped_logs;
+
+        printf("%s%s(%d) - %s: %s\n",
+               is_error ? "ERROR " : "",
+               file,
+               line,
+               function,
+               msg);
+    }
+
+    [[nodiscard]] bool frames_were_dropped() const { return dropped_logs > 0; }
+    void reset() { dropped_logs = 0; }
+
+  private:
+    size_t dropped_logs;
+} introspective_logger;
+
+static void
 reporter(int is_error,
          const char* file,
          int line,
          const char* function,
          const char* msg)
 {
-    fprintf(is_error ? stderr : stdout,
-            "%s%s(%d) - %s: %s\n",
-            is_error ? "ERROR " : "",
-            file,
-            line,
-            function,
-            msg);
+    introspective_logger.report_and_inspect(
+      is_error, file, line, function, msg);
 }
 
 /// Helper for passing size static strings as function args.
@@ -46,13 +74,12 @@ reporter(int is_error,
 #define DEVOK(e) CHECK(Device_Ok == (e))
 #define OK(e) CHECK(AcquireStatus_Ok == (e))
 
-int
-main()
+void
+configure(AcquireRuntime* runtime, std::string_view camera_type)
 {
-
-    auto runtime = acquire_init(reporter);
-    auto dm = acquire_device_manager(runtime);
     CHECK(runtime);
+
+    const DeviceManager* dm = acquire_device_manager(runtime);
     CHECK(dm);
 
     AcquireProperties props = {};
@@ -60,7 +87,8 @@ main()
 
     DEVOK(device_manager_select(dm,
                                 DeviceKind_Camera,
-                                SIZED("simulated.*radial.*") - 1,
+                                camera_type.data(),
+                                camera_type.size(),
                                 &props.video[0].camera.identifier));
     DEVOK(device_manager_select(dm,
                                 DeviceKind_Storage,
@@ -69,19 +97,22 @@ main()
 
     OK(acquire_configure(runtime, &props));
 
-    AcquirePropertyMetadata metadata = { 0 };
-    OK(acquire_get_configuration_metadata(runtime, &metadata));
-
     props.video[0].camera.settings.binning = 1;
     props.video[0].camera.settings.pixel_type = SampleType_u16;
     props.video[0].camera.settings.shape = {
         .x = 1920,
         .y = 1080,
     };
+    props.video[0].camera.settings.exposure_time_us = 1; // very small exposure
+
     props.video[0].max_frame_count = 100;
 
     OK(acquire_configure(runtime, &props));
+}
 
+void
+acquire(AcquireRuntime* runtime)
+{
     const auto next = [](VideoFrame* cur) -> VideoFrame* {
         return (VideoFrame*)(((uint8_t*)cur) + cur->bytes_of_frame);
     };
@@ -91,51 +122,71 @@ main()
         return (uint8_t*)end - (uint8_t*)cur;
     };
 
-    struct clock clock
-    {};
+    AcquireProperties props = {};
+    OK(acquire_get_configuration(runtime, &props));
+
     // expected time to acquire frames + 100%
     static double time_limit_ms =
-      (props.video[0].max_frame_count / 6.0) * 1000.0 * 2.0;
+      (props.video[0].max_frame_count / 3.0) * 1000.0 * 2.0;
+
+    struct clock clock = {};
     clock_init(&clock);
     clock_shift_ms(&clock, time_limit_ms);
+
     OK(acquire_start(runtime));
     {
         uint64_t nframes = 0;
         while (nframes < props.video[0].max_frame_count) {
-            struct clock throttle
-            {};
+            struct clock throttle = {};
             clock_init(&throttle);
+
             EXPECT(clock_cmp_now(&clock) < 0,
                    "Timeout at %f ms",
                    clock_toc_ms(&clock) + time_limit_ms);
+
             VideoFrame *beg, *end, *cur;
+
             OK(acquire_map_read(runtime, 0, &beg, &end));
             for (cur = beg; cur < end; cur = next(cur)) {
-                LOG("stream %d counting frame w id %d", 0, cur->frame_id);
-                CHECK(cur->shape.dims.width ==
-                      props.video[0].camera.settings.shape.x);
-                CHECK(cur->shape.dims.height ==
-                      props.video[0].camera.settings.shape.y);
                 ++nframes;
             }
-            {
-                uint32_t n = (uint32_t)consumed_bytes(beg, end);
-                OK(acquire_unmap_read(runtime, 0, n));
-                if (n)
-                    LOG("stream %d consumed bytes %d", 0, n);
-            }
-            clock_sleep_ms(&throttle, 100.0f);
 
-            LOG("stream %d nframes %d. remaining time %f s",
-                0,
-                nframes,
-                -1e-3 * clock_toc_ms(&clock));
+            uint32_t n = (uint32_t)consumed_bytes(beg, end);
+            OK(acquire_unmap_read(runtime, 0, n));
+
+            clock_sleep_ms(&throttle, 100.0f);
         }
 
         CHECK(nframes == props.video[0].max_frame_count);
     }
 
     OK(acquire_stop(runtime));
-    OK(acquire_shutdown(runtime));
-    return 0;
+}
+
+int
+main()
+{
+    int retval = 1;
+
+    AcquireRuntime* runtime = acquire_init(reporter);
+
+    try {
+        configure(runtime, "simulated.*sin*");
+        acquire(runtime);
+        CHECK(!introspective_logger.frames_were_dropped());
+
+        introspective_logger.reset();
+
+        configure(runtime, "simulated.*empty.*");
+        acquire(runtime);
+        CHECK(introspective_logger.frames_were_dropped());
+
+        retval = 0;
+    } catch (const std::exception& e) {
+        ERR("Exception: %s", e.what());
+    }
+
+    acquire_shutdown(runtime);
+
+    return retval;
 }

--- a/acquire-driver-common/tests/integration/switch-storage-identifier.cpp
+++ b/acquire-driver-common/tests/integration/switch-storage-identifier.cpp
@@ -129,7 +129,7 @@ validate_storage_tiff()
     EXPECT(file_size >= 64 * 48 * nframes,
            "Expected file to have size at least %d (has size %d): %s",
            64 * 48 * nframes,
-           file_size,
+           (int)file_size,
            file_path.c_str());
 }
 
@@ -169,7 +169,7 @@ validate_storage_raw()
     EXPECT(file_size == (sizeof(VideoFrame) + 64 * 48) * nframes,
            "Expected file to have size %d (has size %d): %s",
            64 * 48 * nframes,
-           file_size,
+           (int)file_size,
            file_path.c_str());
 }
 


### PR DESCRIPTION
Small PR to fix some warnings that popped up when I was building against clang 18.

Warnings are along the lines of:

```
warning: format specifies type 'int' but the argument has type 'uintmax_t' (aka 'unsigned long')
```