### PR TITLE
fixing some printf-based warnings

### DIFF
--- a/acquire-driver-common/tests/integration/switch-storage-identifier.cpp
+++ b/acquire-driver-common/tests/integration/switch-storage-identifier.cpp
@@ -129,7 +129,7 @@ validate_storage_tiff()
     EXPECT(file_size >= 64 * 48 * nframes,
            "Expected file to have size at least %d (has size %d): %s",
            64 * 48 * nframes,
-           file_size,
+           (int)file_size,
            file_path.c_str());
 }
 
@@ -169,7 +169,7 @@ validate_storage_raw()
     EXPECT(file_size == (sizeof(VideoFrame) + 64 * 48) * nframes,
            "Expected file to have size %d (has size %d): %s",
            64 * 48 * nframes,
-           file_size,
+           (int)file_size,
            file_path.c_str());
 }
 


### PR DESCRIPTION
Small PR to fix some warnings that popped up when I was building against clang 18.

Warnings are related to some printf's and along the lines of:

```
warning: format specifies type 'int' but the argument has type 'uintmax_t' (aka 'unsigned long')
```